### PR TITLE
feature(gitlogtree): add tree for git log

### DIFF
--- a/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
@@ -138,7 +138,7 @@ namespace GitOut.Features.Git.Log.Converters
 
             if (!(node.Bottom is Line bottomLayer))
             {
-                throw new ArgumentException("no bottomlayer when commit is missing", nameof(node));
+                throw new ArgumentException("no bottom layer when commit is missing", nameof(node));
             }
 
             if (topLayer.Up == bottomLayer.Down)

--- a/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
@@ -133,12 +133,12 @@ namespace GitOut.Features.Git.Log.Converters
         {
             if (!(node.Top is Line topLayer))
             {
-                throw new ArgumentException("no toplayer when commit is missing");
+                throw new ArgumentException("no top layer when commit is missing", nameof(node));
             }
 
             if (!(node.Bottom is Line bottomLayer))
             {
-                throw new ArgumentException("no bottomlayer when commit is missing");
+                throw new ArgumentException("no bottomlayer when commit is missing", nameof(node));
             }
 
             if (topLayer.Up == bottomLayer.Down)

--- a/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace GitOut.Features.Git.Log.Converters
+{
+    public class TreeNodePathDataConverter : IMultiValueConverter
+    {
+        private const int XDistance = 15;
+        private const int XOffset = 10;
+        private static readonly Size Size = new Size(6, 6);
+
+        public object Convert(object[] value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value.Length != 2
+                || !(value[0] is GitTreeNode node)
+                || !(value[1] is double height))
+            {
+                return DependencyProperty.UnsetValue;
+            }
+
+            if (!node.IsCommit)
+            {
+                return DrawBoth(node, height);
+            }
+
+            var geometry = new PathGeometry();
+            if (node.Bottom is Line downLine && downLine.Up == downLine.Down)
+            {
+                geometry.AddGeometry(new EllipseGeometry(new Point(downLine.Up * XDistance + XOffset, height / 2), Size.Height / 2, Size.Width / 2));
+            }
+            else if (node.Top is Line upLine && upLine.Up == upLine.Down)
+            {
+                geometry.AddGeometry(new EllipseGeometry(new Point(upLine.Up * XDistance + XOffset, height / 2), Size.Height / 2, Size.Width / 2));
+            }
+
+            DrawTop(geometry, node, height);
+            DrawBottom(geometry, node, height);
+            return geometry;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+
+        private void DrawBottom(PathGeometry geometry, GitTreeNode node, double height)
+        {
+            if (!(node.Bottom is Line line))
+            {
+                return;
+            }
+
+            double bottomXCoordinate = XOffset + line.Down * XDistance;
+
+            if (line.Up == line.Down)
+            {
+                double offset = Size.Height / 2;
+                double middleXCoordinate = XOffset + line.Up * XDistance;
+                double middleYCoordinate = height / 2 + offset;
+
+                geometry.Figures.Add(new PathFigure(new Point(middleXCoordinate, middleYCoordinate), new[] { new LineSegment(new Point(bottomXCoordinate, height), true) }, false));
+            }
+            else
+            {
+                var nodes = new List<BezierSegment>();
+                double offset = node.IsCommit ? Size.Width / 2 : 0;
+                if (line.Up < line.Down)
+                {
+                    nodes.Add(new BezierSegment(
+                        new Point(bottomXCoordinate, height * 3 / 4),
+                        new Point(bottomXCoordinate, height / 2),
+                        new Point(XOffset + line.Up * XDistance + offset, height / 2),
+                        true
+                    ));
+                }
+                else
+                {
+                    nodes.Add(new BezierSegment(
+                        new Point(bottomXCoordinate, height * 3 / 4),
+                        new Point(bottomXCoordinate, height / 2),
+                        new Point(XOffset + line.Up * XDistance - offset, height / 2),
+                        true
+                    ));
+                }
+                geometry.Figures.Add(new PathFigure(new Point(bottomXCoordinate, height), nodes, false));
+            }
+        }
+
+        private void DrawTop(PathGeometry geometry, GitTreeNode node, double height)
+        {
+            if (!(node.Top is Line line))
+            {
+                return;
+            }
+
+            double upperXCoordinate = XOffset + line.Up * XDistance;
+
+            if (line.Up == line.Down)
+            {
+                double sameOffset = node.IsCommit ? Size.Height / 2 : 0;
+                double middleXCoordinate = XOffset + line.Down * XDistance;
+                double middleYCoordinate = height / 2 - sameOffset;
+                geometry.Figures.Add(new PathFigure(new Point(upperXCoordinate, 0), new[] { new LineSegment(new Point(middleXCoordinate, middleYCoordinate), true) }, false));
+                return;
+            }
+            BezierSegment bezierSegment;
+            double offset = Size.Width / 2;
+
+            if (line.Up < line.Down)
+            {
+                bezierSegment = new BezierSegment(
+                    new Point(upperXCoordinate, height / 4),
+                    new Point(upperXCoordinate, height / 2),
+                    new Point(XOffset + line.Down * XDistance - offset, height / 2),
+                    true
+                );
+            }
+            else
+            {
+                bezierSegment = new BezierSegment(
+                    new Point(upperXCoordinate, height / 4),
+                    new Point(upperXCoordinate, height / 2),
+                    new Point(XOffset + line.Down * XDistance + offset, height / 2),
+                    true
+                );
+            }
+            geometry.Figures.Add(new PathFigure(new Point(upperXCoordinate, 0), new[] { bezierSegment }, false));
+        }
+
+        private PathGeometry DrawBoth(GitTreeNode node, double height)
+        {
+            if (!(node.Top is Line topLayer))
+            {
+                throw new ArgumentException("no toplayer when commit is missing");
+            }
+
+            if (!(node.Bottom is Line bottomLayer))
+            {
+                throw new ArgumentException("no bottomlayer when commit is missing");
+            }
+
+            if (topLayer.Up == bottomLayer.Down)
+            {
+                return new PathGeometry
+                {
+                    Figures =
+                    {
+                        new PathFigure(new Point(XOffset + XDistance * topLayer.Up, 0), new[] { new LineSegment(new Point(XOffset + XDistance * bottomLayer.Down, height), true) }, false)
+                    }
+                };
+            }
+
+            var pathFigure = new PathFigure(
+                new Point(XOffset + node.Top.GetValueOrDefault().Up * XDistance, 0),
+                new[]
+                {
+                    new BezierSegment(
+                        new Point(XOffset + topLayer.Up * XDistance, height * 0.9),
+                        new Point(XOffset + bottomLayer.Down * XDistance, height * 0.3),
+                        new Point(XOffset + bottomLayer.Down * XDistance, height),
+                        true
+                    )
+                },
+                false);
+
+            return new PathGeometry { Figures = { pathFigure } };
+        }
+    }
+}

--- a/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeNodePathDataConverter.cs
@@ -42,8 +42,7 @@ namespace GitOut.Features.Git.Log.Converters
             return geometry;
         }
 
-        public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
-            => throw new NotSupportedException();
+        public object[]? ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture) => null;
 
         private void DrawBottom(PathGeometry geometry, GitTreeNode node, double height)
         {

--- a/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
@@ -18,7 +18,7 @@ namespace GitOut.Features.Git.Log.Converters
             }
 
             int maxIndex = gitTreeEvent.Nodes
-                .Select(n => new [] { n.Top?.Up ?? 0, n.Top?.Down ?? 0, n.Bottom?.Down ?? 0})
+                .Select(n => new[] { n.Top?.Up ?? 0, n.Top?.Down ?? 0, n.Bottom?.Down ?? 0 })
                 .SelectMany(layers => layers)
                 .Max();
 

--- a/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+
+namespace GitOut.Features.Git.Log.Converters
+{
+    public class TreeToMarginConverter : IValueConverter
+    {
+        public const int Distance = 20;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is GitTreeEvent gitTreeEvent))
+            {
+                return DependencyProperty.UnsetValue;
+            }
+
+            int maxIndex = gitTreeEvent.Nodes
+                .Select(n => new [] { n.Top?.Up ?? 0, n.Top?.Down ?? 0, n.Bottom?.Down ?? 0})
+                .SelectMany(layers => layers)
+                .Max();
+
+            return new Thickness((maxIndex+1) * Distance, 0, 0, 0);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+    }
+}

--- a/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
@@ -22,7 +22,7 @@ namespace GitOut.Features.Git.Log.Converters
                 .SelectMany(layers => layers)
                 .Max();
 
-            return new Thickness((maxIndex+1) * Distance, 0, 0, 0);
+            return new Thickness(10 + (maxIndex + 1) * Distance, 0, 0, 0);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
@@ -8,7 +8,7 @@ namespace GitOut.Features.Git.Log.Converters
 {
     public class TreeToMarginConverter : IValueConverter
     {
-        public const int Distance = 20;
+        public const int Distance = 15;
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
@@ -25,6 +25,6 @@ namespace GitOut.Features.Git.Log.Converters
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => throw new NotSupportedException();
+            => Binding.DoNothing;
     }
 }

--- a/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
+++ b/GitOut/Features/Git/Log/Converters/TreeToMarginConverter.cs
@@ -18,8 +18,7 @@ namespace GitOut.Features.Git.Log.Converters
             }
 
             int maxIndex = gitTreeEvent.Nodes
-                .Select(n => new[] { n.Top?.Up ?? 0, n.Top?.Down ?? 0, n.Bottom?.Down ?? 0 })
-                .SelectMany(layers => layers)
+                .SelectMany(n => new[] { n.Top?.Up ?? 0, n.Top?.Down ?? 0, n.Bottom?.Down ?? 0 })
                 .Max();
 
             return new Thickness(10 + (maxIndex + 1) * Distance, 0, 0, 0);

--- a/GitOut/Features/Git/Log/GitLogPage.xaml
+++ b/GitOut/Features/Git/Log/GitLogPage.xaml
@@ -5,15 +5,19 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
     xmlns:local="clr-namespace:GitOut.Features.Git.Log"
-    xmlns:git="clr-namespace:GitOut.Features.Git.Diagnostics"
+    xmlns:lc="clr-namespace:GitOut.Features.Git.Log.Converters"
     xmlns:converters="clr-namespace:GitOut.Features.Wpf.Converters"
     mc:Ignorable="d" 
-    d:DataContext="{d:DesignInstance Type=local:GitLogViewModel}"
+    d:DataContext="{d:DesignInstance Type={x:Type local:GitLogViewModel}}"
     d:DesignHeight="450"
     d:DesignWidth="800"
 >
     <UserControl.Resources>
         <converters:BooleanToFontWeightConverter x:Key="BooleanToFontWeightConverter" />
+        <converters:ColorToBrushConverter x:Key="ColorToBrushConverter" />
+        <lc:TreeToMarginConverter x:Key="TreeToMarginConverter" />
+        <lc:TreeNodePathDataConverter x:Key="TreeNodePathDataConverter" />
+
         <Style x:Key="BranchStyle" TargetType="{x:Type Border}">
             <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueLightBrush}" />
@@ -35,9 +39,9 @@
                         <ControlTemplate.Resources>
                             <Style TargetType="{x:Type ListViewItem}">
                                 <Setter Property="MinHeight" Value="28"/>
-                                <Setter Property="Padding" Value="2"/>
+                                <Setter Property="Padding" Value="0"/>
                                 <Setter Property="BorderBrush" Value="Transparent"/>
-                                <Setter Property="BorderThickness" Value="0 1 0 1"/>
+                                <Setter Property="BorderThickness" Value="0"/>
                                 <Setter Property="Foreground" Value="{DynamicResource MaterialGray100}"/>
                                 <Setter Property="Template">
                                     <Setter.Value>
@@ -60,13 +64,11 @@
                                 </Setter>
                                 <Style.Triggers>
                                     <Trigger Property="IsSelected" Value="True">
-                                        <Setter Property="BorderThickness" Value="0 1 0 1"/>
                                         <Setter Property="BorderBrush" Value="{DynamicResource MaterialGray800}"/>
                                         <Setter Property="Background" Value="{DynamicResource MaterialBackgroundHover}"/>
                                         <Setter Property="Foreground" Value="{DynamicResource MaterialGray50}"/>
                                     </Trigger>
                                     <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="BorderThickness" Value="0 1 0 1"/>
                                         <Setter Property="BorderBrush" Value="{DynamicResource MaterialGray800}"/>
                                         <Setter Property="Background" Value="{DynamicResource MaterialBackgroundHover}"/>
                                         <Setter Property="Foreground" Value="{DynamicResource MaterialGray50}"/>
@@ -110,34 +112,76 @@
             Style="{StaticResource GitLogListStyle}"
         >
             <ListView.ItemTemplate>
-                <DataTemplate DataType="git:GitHistoryEvent">
-                    <Grid>
+                <DataTemplate DataType="{x:Type local:GitTreeEvent}">
+                    <Grid x:Name="outerGrid" Height="28">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <ItemsControl ItemsSource="{Binding Branches}" VerticalAlignment="Center">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <StackPanel />
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Border Style="{StaticResource BranchStyle}">
-                                        <TextBlock Text="{Binding Name}"/>
-                                    </Border>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                        <TextBlock Grid.Column="1" FontWeight="{Binding IsHead, Converter={StaticResource BooleanToFontWeightConverter}}" Text="{Binding Subject, Mode=OneWay}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
-                        <TextBlock Grid.Column="2">
-                            <Run Text="{Binding Author.Name, Mode=OneWay}" />
-                            <Run Text="{Binding Author.Email, Mode=OneWay}" />
-                            <Run Text="{Binding AuthorDate, Mode=OneWay}" />
-                        </TextBlock>
+                        <Grid>
+                            <ItemsControl ItemsSource="{Binding Nodes}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <Canvas />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Path
+                                            Fill="Transparent"
+                                            StrokeThickness="2"
+                                            Height="28"
+                                            Stroke="{Binding Color, Converter={StaticResource ColorToBrushConverter}}"
+                                        >
+                                            <Path.Data>
+                                                <MultiBinding Converter="{StaticResource TreeNodePathDataConverter}">
+                                                    <Binding Path="." />
+                                                    <Binding Path="ActualHeight" ElementName="outerGrid" />
+                                                </MultiBinding>
+                                            </Path.Data>
+                                        </Path>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Grid>
+                        <Grid
+                            Grid.Column="1"
+                            Margin="{Binding DataContext, ElementName=outerGrid, Converter={StaticResource TreeToMarginConverter}}"
+                            DataContext="{Binding Event}"
+                        >
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ItemsControl
+                                Grid.Column="0"
+                                VerticalAlignment="Center"
+                                ItemsSource="{Binding Branches}"
+                            >
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Style="{StaticResource BranchStyle}">
+                                            <TextBlock Text="{Binding Name}"/>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <TextBlock
+                                Grid.Column="1"
+                                FontWeight="{Binding IsHead, Converter={StaticResource BooleanToFontWeightConverter}}"
+                                Text="{Binding Subject, Mode=OneWay}"
+                                VerticalAlignment="Center"
+                                TextTrimming="CharacterEllipsis"
+                            />
+                            <TextBlock Grid.Column="2">
+                                <Run Text="{Binding Author.Name, Mode=OneWay}" />
+                                <Run Text="{Binding Author.Email, Mode=OneWay}" />
+                                <Run Text="{Binding AuthorDate, Mode=OneWay}" />
+                            </TextBlock>
+                        </Grid>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/GitOut/Features/Git/Log/GitLogPage.xaml
+++ b/GitOut/Features/Git/Log/GitLogPage.xaml
@@ -153,7 +153,6 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <ItemsControl
                                 Grid.Column="0"

--- a/GitOut/Features/Git/Log/GitLogViewModel.cs
+++ b/GitOut/Features/Git/Log/GitLogViewModel.cs
@@ -49,7 +49,7 @@ namespace GitOut.Features.Git.Log
             var stopwatch = Stopwatch.StartNew();
             var events = new List<GitTreeEvent>();
             IEnumerable<TreeBuildingLeaf> leafs = Enumerable.Empty<TreeBuildingLeaf>();
-            GitTreeEvent.BeginProcessing();
+            GitTreeEvent.ResetColors();
             foreach (GitHistoryEvent item in log)
             {
                 var node = new GitTreeEvent(item);

--- a/GitOut/Features/Git/Log/GitLogViewModel.cs
+++ b/GitOut/Features/Git/Log/GitLogViewModel.cs
@@ -49,13 +49,11 @@ namespace GitOut.Features.Git.Log
             var stopwatch = Stopwatch.StartNew();
             var events = new List<GitTreeEvent>();
             IEnumerable<TreeBuildingLeaf> leafs = Enumerable.Empty<TreeBuildingLeaf>();
-            GitTreeEvent? previous = null;
             foreach (GitHistoryEvent item in log)
             {
-                var node = new GitTreeEvent(item, previous?.ColorIndex ?? 0);
+                var node = new GitTreeEvent(item);
                 leafs = node.Process(leafs);
                 events.Add(node);
-                previous = node;
             }
             Trace.WriteLine($"Built git tree: {stopwatch.Elapsed.TotalMilliseconds}ms");
 

--- a/GitOut/Features/Git/Log/GitLogViewModel.cs
+++ b/GitOut/Features/Git/Log/GitLogViewModel.cs
@@ -49,6 +49,7 @@ namespace GitOut.Features.Git.Log
             var stopwatch = Stopwatch.StartNew();
             var events = new List<GitTreeEvent>();
             IEnumerable<TreeBuildingLeaf> leafs = Enumerable.Empty<TreeBuildingLeaf>();
+            GitTreeEvent.BeginProcessing();
             foreach (GitHistoryEvent item in log)
             {
                 var node = new GitTreeEvent(item);

--- a/GitOut/Features/Git/Log/GitLogViewModel.cs
+++ b/GitOut/Features/Git/Log/GitLogViewModel.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
 using System.Windows.Data;
 using GitOut.Features.Navigation;
 using GitOut.Features.Wpf;
@@ -21,18 +23,18 @@ namespace GitOut.Features.Git.Log
             _ = options ?? throw new ArgumentNullException(nameof(options), "Options may not be null");
             title.Title = "Log";
 
-            var entries = new ObservableCollection<GitHistoryEvent>();
+            var entries = new ObservableCollection<GitTreeEvent>();
             BindingOperations.EnableCollectionSynchronization(entries, entriesLock);
             Entries = CollectionViewSource.GetDefaultView(entries);
-            Entries.SortDescriptions.Add(new SortDescription("AuthorDate", ListSortDirection.Descending));
 
             options.Repository.ExecuteLogAsync()
+                .ContinueWith(task => BuildTree(task.Result))
                 .ContinueWith(task =>
                 {
-                    IEnumerable<GitHistoryEvent> history = task.Result;
+                    IEnumerable<GitTreeEvent> history = task.Result;
                     lock (entriesLock)
                     {
-                        foreach (GitHistoryEvent item in history)
+                        foreach (GitTreeEvent item in history)
                         {
                             entries.Add(item);
                         }
@@ -41,5 +43,23 @@ namespace GitOut.Features.Git.Log
         }
 
         public ICollectionView Entries { get; }
+
+        private IEnumerable<GitTreeEvent> BuildTree(IEnumerable<GitHistoryEvent> log)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var events = new List<GitTreeEvent>();
+            IEnumerable<TreeBuildingLeaf> leafs = Enumerable.Empty<TreeBuildingLeaf>();
+            GitTreeEvent? previous = null;
+            foreach (GitHistoryEvent item in log)
+            {
+                var node = new GitTreeEvent(item, previous?.ColorIndex ?? 0);
+                leafs = node.Process(leafs);
+                events.Add(node);
+                previous = node;
+            }
+            Trace.WriteLine($"Built git tree: {stopwatch.Elapsed.TotalMilliseconds}ms");
+
+            return events;
+        }
     }
 }

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -46,7 +46,7 @@ namespace GitOut.Features.Git.Log
                         bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.Parent, leaf.Current));
                         if (Event.MergedParent != null)
                         {
-                            var node = new GitTreeNode(null, new Line(from, to++), GetNextAvailableColor(), true);
+                            var node = GitTreeNode.WithBottomLine(new Line(from, to++), GetNextAvailableColor(), true);
                             nodes.Add(node);
                             bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.MergedParent, node));
                         }
@@ -61,14 +61,14 @@ namespace GitOut.Features.Git.Log
             }
             if (!processedCommit)
             {
-                var node = new GitTreeNode(null, new Line(from, to), GetNextAvailableColor(), true);
+                var node = GitTreeNode.WithBottomLine(new Line(from, to), GetNextAvailableColor(), true);
                 nodes.Add(node);
                 if (Event.Parent != null)
                 {
                     bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.Parent, node));
                     if (Event.MergedParent != null)
                     {
-                        var mergedNode = new GitTreeNode(null, new Line(from, to++), GetNextAvailableColor(), true);
+                        var mergedNode = GitTreeNode.WithBottomLine(new Line(from, to++), GetNextAvailableColor(), true);
                         nodes.Add(mergedNode);
                         bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.MergedParent, mergedNode));
                     }
@@ -111,7 +111,7 @@ namespace GitOut.Features.Git.Log
                     if (CommitIndex == -1)
                     {
                         CommitIndex = to++;
-                        node = new GitTreeNode(new Line(from++, CommitIndex), null, leaf.Current.Color, true);
+                        node = GitTreeNode.WithTopLine(new Line(from++, CommitIndex), leaf.Current.Color, true);
 
                         // add node to topleafs, so that it's processed in ProcessBottom
                         // done only for the first branch that finds the commit, the other would be duplicates
@@ -120,14 +120,14 @@ namespace GitOut.Features.Git.Log
                     }
                     else
                     {
-                        node = new GitTreeNode(new Line(from++, CommitIndex), null, leaf.Current.Color, true);
+                        node = GitTreeNode.WithTopLine(new Line(from++, CommitIndex), leaf.Current.Color, true);
                         SetColorAvailable(leaf.Current.Color);
                     }
                     nodes.Add(node);
                 }
                 else
                 {
-                    var newNode = new GitTreeNode(new Line(from++, to++), null, leaf.Current.Color, false);
+                    var newNode = GitTreeNode.WithTopLine(new Line(from++, to++), leaf.Current.Color, false);
                     nodes.Add(newNode);
                     topLeafs.Add(TreeBuildingLeaf.WithParent(leaf.LookingFor!, newNode));
                 }

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Media;
 
@@ -27,6 +28,8 @@ namespace GitOut.Features.Git.Log
         public IReadOnlyCollection<GitTreeNode> Nodes => nodes;
 
         public IEnumerable<TreeBuildingLeaf> Process(IEnumerable<TreeBuildingLeaf> leafs) => ProcessBottom(ProcessTop(leafs));
+
+        public static void BeginProcessing() => colors.ForEach(c => c.Available = true);
 
         private IEnumerable<TreeBuildingLeaf> ProcessBottom(IEnumerable<TreeBuildingLeaf> leafs)
         {

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -43,12 +43,12 @@ namespace GitOut.Features.Git.Log
                     if (Event.Parent != null)
                     {
                         leaf.Current.Bottom = new Line(from, to++);
-                        bottomLeafs.Add(new TreeBuildingLeaf(Event.Parent, leaf.Current));
+                        bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.Parent, leaf.Current));
                         if (Event.MergedParent != null)
                         {
                             var node = new GitTreeNode(null, new Line(from, to++), GetNextAvailableColor(), true);
                             nodes.Add(node);
-                            bottomLeafs.Add(new TreeBuildingLeaf(Event.MergedParent, node));
+                            bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.MergedParent, node));
                         }
                     }
                     ++from;
@@ -56,19 +56,22 @@ namespace GitOut.Features.Git.Log
                 else
                 {
                     leaf.Current.Bottom = new Line(from++, to++);
-                    bottomLeafs.Add(new TreeBuildingLeaf(leaf.LookingFor, leaf.Current));
+                    bottomLeafs.Add(TreeBuildingLeaf.WithParent(leaf.LookingFor!, leaf.Current));
                 }
             }
             if (!processedCommit)
             {
                 var node = new GitTreeNode(null, new Line(from, to), GetNextAvailableColor(), true);
                 nodes.Add(node);
-                bottomLeafs.Add(new TreeBuildingLeaf(Event.Parent, node));
-                if (Event.MergedParent != null)
+                if (Event.Parent != null)
                 {
-                    var mergedNode = new GitTreeNode(null, new Line(from, to++), GetNextAvailableColor(), true);
-                    nodes.Add(mergedNode);
-                    bottomLeafs.Add(new TreeBuildingLeaf(Event.MergedParent, mergedNode));
+                    bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.Parent, node));
+                    if (Event.MergedParent != null)
+                    {
+                        var mergedNode = new GitTreeNode(null, new Line(from, to++), GetNextAvailableColor(), true);
+                        nodes.Add(mergedNode);
+                        bottomLeafs.Add(TreeBuildingLeaf.WithParent(Event.MergedParent, mergedNode));
+                    }
                 }
             }
             return bottomLeafs;
@@ -113,7 +116,7 @@ namespace GitOut.Features.Git.Log
                         // add node to topleafs, so that it's processed in ProcessBottom
                         // done only for the first branch that finds the commit, the other would be duplicates
                         // the LookingFor is unused later - it is the parents of the Event that will be used as LookingFor
-                        topLeafs.Add(new TreeBuildingLeaf(null, node));
+                        topLeafs.Add(TreeBuildingLeaf.WithoutParent(node));
                     }
                     else
                     {
@@ -126,7 +129,7 @@ namespace GitOut.Features.Git.Log
                 {
                     var newNode = new GitTreeNode(new Line(from++, to++), null, leaf.Current.Color, false);
                     nodes.Add(newNode);
-                    topLeafs.Add(new TreeBuildingLeaf(leaf.LookingFor, newNode));
+                    topLeafs.Add(TreeBuildingLeaf.WithParent(leaf.LookingFor!, newNode));
                 }
             }
             if (CommitIndex == -1)

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -20,10 +20,10 @@ namespace GitOut.Features.Git.Log
         };
 
         private readonly List<GitTreeNode> nodes = new List<GitTreeNode>();
+        private int commitIndex = -1;
 
         public GitTreeEvent(GitHistoryEvent historyEvent) => Event = historyEvent;
 
-        public int CommitIndex { get; set; } = -1;
         public GitHistoryEvent Event { get; }
         public IReadOnlyCollection<GitTreeNode> Nodes => nodes;
 
@@ -39,7 +39,7 @@ namespace GitOut.Features.Git.Log
             bool processedCommit = false;
             foreach (TreeBuildingLeaf leaf in leafs)
             {
-                if (from == CommitIndex)
+                if (from == commitIndex)
                 {
                     processedCommit = true;
 
@@ -111,10 +111,10 @@ namespace GitOut.Features.Git.Log
                 if (leaf.LookingFor == Event)
                 {
                     GitTreeNode node;
-                    if (CommitIndex == -1)
+                    if (commitIndex == -1)
                     {
-                        CommitIndex = to++;
-                        node = GitTreeNode.WithTopLine(new Line(from++, CommitIndex), leaf.Current.Color, true);
+                        commitIndex = to++;
+                        node = GitTreeNode.WithTopLine(new Line(from++, commitIndex), leaf.Current.Color, true);
 
                         // add node to topleafs, so that it's processed in ProcessBottom
                         // done only for the first branch that finds the commit, the other would be duplicates
@@ -123,7 +123,7 @@ namespace GitOut.Features.Git.Log
                     }
                     else
                     {
-                        node = GitTreeNode.WithTopLine(new Line(from++, CommitIndex), leaf.Current.Color, true);
+                        node = GitTreeNode.WithTopLine(new Line(from++, commitIndex), leaf.Current.Color, true);
                         SetColorAvailable(leaf.Current.Color);
                     }
                     nodes.Add(node);
@@ -135,9 +135,9 @@ namespace GitOut.Features.Git.Log
                     topLeafs.Add(TreeBuildingLeaf.WithParent(leaf.LookingFor!, newNode));
                 }
             }
-            if (CommitIndex == -1)
+            if (commitIndex == -1)
             {
-                CommitIndex = to;
+                commitIndex = to;
             }
 
             return topLeafs;

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -1,0 +1,131 @@
+﻿using System.Collections.Generic;
+using System.Windows.Media;
+
+namespace GitOut.Features.Git.Log
+{
+    public class GitTreeEvent
+    {
+        private static readonly List<Color> colors;
+        private readonly List<GitTreeNode> nodes;
+        private int colorIndex;
+
+        static GitTreeEvent() => colors = new List<Color>
+            {
+                Color.FromArgb(255, 255, 255, 0),
+                Color.FromArgb(255, 255, 200, 100),
+                Color.FromArgb(255, 0, 255, 255),
+                Color.FromArgb(255, 100, 255, 100),
+                Color.FromArgb(255, 255, 255, 255),
+                Color.FromArgb(255, 200, 200, 200),
+                Color.FromArgb(255, 100, 100, 100),
+                Color.FromArgb(255, 50, 50, 50),
+            };
+
+        public GitTreeEvent(GitHistoryEvent historyEvent, int colorIndex)
+        {
+            this.colorIndex = colorIndex;
+            Event = historyEvent;
+            CommitIndex = -1;
+            nodes = new List<GitTreeNode>();
+        }
+
+        public int CommitIndex { get; set; }
+
+        public GitHistoryEvent Event { get; }
+        public IReadOnlyCollection<GitTreeNode> Nodes => nodes;
+
+        public int ColorIndex => colorIndex;
+
+        public IEnumerable<TreeBuildingLeaf> Process(IEnumerable<TreeBuildingLeaf> leafs) => ProcessBottom(ProcessTop(leafs));
+
+        private IEnumerable<TreeBuildingLeaf> ProcessBottom(IEnumerable<TreeBuildingLeaf> leafs)
+        {
+            int from = 0;
+            int to = 0;
+            var bottomLeafs = new List<TreeBuildingLeaf>();
+            bool processedCommit = false;
+            foreach (TreeBuildingLeaf leaf in leafs)
+            {
+                if (from == CommitIndex)
+                {
+                    processedCommit = true;
+
+                    if (Event.Parent != null)
+                    {
+                        leaf.Current.Bottom = new Line(from, to++);
+                        bottomLeafs.Add(new TreeBuildingLeaf(Event.Parent, leaf.Current));
+                        if (Event.MergedParent != null)
+                        {
+                            var node = new GitTreeNode(null, new Line(from, to++), NextColor(), true);
+                            nodes.Add(node);
+                            bottomLeafs.Add(new TreeBuildingLeaf(Event.MergedParent, node));
+                        }
+                    }
+                    ++from;
+                }
+                else
+                {
+                    leaf.Current.Bottom = new Line(from++, to++);
+                    bottomLeafs.Add(new TreeBuildingLeaf(leaf.LookingFor, leaf.Current));
+                }
+            }
+            if (!processedCommit)
+            {
+                var node = new GitTreeNode(null, new Line(from, to), NextColor(), true);
+                nodes.Add(node);
+                bottomLeafs.Add(new TreeBuildingLeaf(Event.Parent, node));
+                if (Event.MergedParent != null)
+                {
+                    var mergedNode = new GitTreeNode(null, new Line(from, to++), NextColor(), true);
+                    nodes.Add(mergedNode);
+                    bottomLeafs.Add(new TreeBuildingLeaf(Event.MergedParent, mergedNode));
+                }
+            }
+            return bottomLeafs;
+        }
+
+        private Color NextColor() => colors[colorIndex++ % (colors.Count - 1)];
+
+        private IEnumerable<TreeBuildingLeaf> ProcessTop(IEnumerable<TreeBuildingLeaf> leafs)
+        {
+            int from = 0;
+            int to = 0;
+            var topLeafs = new List<TreeBuildingLeaf>();
+            foreach (TreeBuildingLeaf leaf in leafs)
+            {
+                if (leaf.LookingFor == Event)
+                {
+                    GitTreeNode node;
+                    if (CommitIndex == -1)
+                    {
+                        CommitIndex = to++;
+                        node = new GitTreeNode(new Line(from++, CommitIndex), null, leaf.Current.Color, true);
+
+                        // add node to topleafs, so that it's processed in ProcessBottom
+                        // done only for the first branch that finds the commit, the other would be duplicates
+                        // the LookingFor is unused later - it is the parents of the Event that will be used as LookingFor
+                        topLeafs.Add(new TreeBuildingLeaf(null, node));
+                    }
+                    else
+                    {
+                        node = new GitTreeNode(new Line(from++, CommitIndex), null, leaf.Current.Color, true);
+                        --colorIndex;
+                    }
+                    nodes.Add(node);
+                }
+                else
+                {
+                    var newNode = new GitTreeNode(new Line(from++, to++), null, leaf.Current.Color, false);
+                    nodes.Add(newNode);
+                    topLeafs.Add(new TreeBuildingLeaf(leaf.LookingFor, newNode));
+                }
+            }
+            if (CommitIndex == -1)
+            {
+                CommitIndex = to;
+            }
+
+            return topLeafs;
+        }
+    }
+}

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -132,7 +132,12 @@ namespace GitOut.Features.Git.Log
                 {
                     var newNode = GitTreeNode.WithTopLine(new Line(from++, to++), leaf.Current.Color, false);
                     nodes.Add(newNode);
-                    topLeafs.Add(TreeBuildingLeaf.WithParent(leaf.LookingFor!, newNode));
+                    if (leaf.LookingFor is null)
+                    {
+                        throw new InvalidOperationException("leaf should have something to look for");
+                    }
+
+                    topLeafs.Add(TreeBuildingLeaf.WithParent(leaf.LookingFor, newNode));
                 }
             }
             if (commitIndex == -1)

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -6,30 +6,23 @@ namespace GitOut.Features.Git.Log
 {
     public class GitTreeEvent
     {
-        private static readonly List<AvailableColor> colors;
-        private readonly List<GitTreeNode> nodes;
-
-        static GitTreeEvent() => colors = new List<AvailableColor>
-            {
-                new AvailableColor(Color.FromArgb(255, 255, 255, 0)),
-                new AvailableColor(Color.FromArgb(255, 255, 200, 100)),
-                new AvailableColor(Color.FromArgb(255, 0, 255, 255)),
-                new AvailableColor(Color.FromArgb(255, 100, 255, 100)),
-                new AvailableColor(Color.FromArgb(255, 255, 255, 255)),
-                new AvailableColor(Color.FromArgb(255, 200, 200, 200)),
-                new AvailableColor(Color.FromArgb(255, 100, 100, 100)),
-                new AvailableColor(Color.FromArgb(255, 50, 50, 50))
-            };
-
-        public GitTreeEvent(GitHistoryEvent historyEvent)
+        private static readonly List<AvailableColor> colors = new List<AvailableColor>
         {
-            Event = historyEvent;
-            CommitIndex = -1;
-            nodes = new List<GitTreeNode>();
-        }
+            new AvailableColor(Color.FromArgb(255, 255, 255, 0)),
+            new AvailableColor(Color.FromArgb(255, 255, 200, 100)),
+            new AvailableColor(Color.FromArgb(255, 0, 255, 255)),
+            new AvailableColor(Color.FromArgb(255, 100, 255, 100)),
+            new AvailableColor(Color.FromArgb(255, 255, 255, 255)),
+            new AvailableColor(Color.FromArgb(255, 200, 200, 200)),
+            new AvailableColor(Color.FromArgb(255, 100, 100, 100)),
+            new AvailableColor(Color.FromArgb(255, 50, 50, 50))
+        };
 
-        public int CommitIndex { get; set; }
+        private readonly List<GitTreeNode> nodes = new List<GitTreeNode>();
 
+        public GitTreeEvent(GitHistoryEvent historyEvent) => Event = historyEvent;
+
+        public int CommitIndex { get; set; } = -1;
         public GitHistoryEvent Event { get; }
         public IReadOnlyCollection<GitTreeNode> Nodes => nodes;
 
@@ -143,15 +136,12 @@ namespace GitOut.Features.Git.Log
 
             return topLeafs;
         }
+
         private class AvailableColor
         {
-            public AvailableColor(Color color)
-            {
-                Available = true;
-                Color = color;
-            }
+            public AvailableColor(Color color) => Color = color;
 
-            public bool Available { get; set; }
+            public bool Available { get; set; } = true;
             public Color Color { get; }
         }
     }

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -29,7 +29,7 @@ namespace GitOut.Features.Git.Log
 
         public IEnumerable<TreeBuildingLeaf> Process(IEnumerable<TreeBuildingLeaf> leafs) => ProcessBottom(ProcessTop(leafs));
 
-        public static void BeginProcessing() => colors.ForEach(c => c.Available = true);
+        public static void ResetColors() => colors.ForEach(c => c.Available = true);
 
         private IEnumerable<TreeBuildingLeaf> ProcessBottom(IEnumerable<TreeBuildingLeaf> leafs)
         {

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -80,27 +80,6 @@ namespace GitOut.Features.Git.Log
             return bottomLeafs;
         }
 
-        private Color GetNextAvailableColor()
-        {
-            AvailableColor nextColor = colors.FirstOrDefault(ac => ac.Available);
-            if (nextColor is null)
-            {
-                colors.ForEach(ac => ac.Available = true);
-                nextColor = colors[0];
-            }
-            nextColor.Available = false;
-            return nextColor.Color;
-        }
-
-        private void SetColorAvailable(Color color)
-        {
-            AvailableColor availableColor = colors.FirstOrDefault(ac => ac.Color == color);
-            if (availableColor != null)
-            {
-                availableColor.Available = true;
-            }
-        }
-
         private IEnumerable<TreeBuildingLeaf> ProcessTop(IEnumerable<TreeBuildingLeaf> leafs)
         {
             int from = 0;
@@ -146,6 +125,27 @@ namespace GitOut.Features.Git.Log
             }
 
             return topLeafs;
+        }
+
+        private Color GetNextAvailableColor()
+        {
+            AvailableColor nextColor = colors.FirstOrDefault(ac => ac.Available);
+            if (nextColor is null)
+            {
+                colors.ForEach(ac => ac.Available = true);
+                nextColor = colors[0];
+            }
+            nextColor.Available = false;
+            return nextColor.Color;
+        }
+
+        private void SetColorAvailable(Color color)
+        {
+            AvailableColor availableColor = colors.FirstOrDefault(ac => ac.Color == color);
+            if (availableColor != null)
+            {
+                availableColor.Available = true;
+            }
         }
 
         private class AvailableColor

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -8,14 +8,14 @@ namespace GitOut.Features.Git.Log
     {
         private static readonly List<AvailableColor> colors = new List<AvailableColor>
         {
-            new AvailableColor(Color.FromArgb(255, 255, 255, 0)),
-            new AvailableColor(Color.FromArgb(255, 255, 200, 100)),
-            new AvailableColor(Color.FromArgb(255, 0, 255, 255)),
-            new AvailableColor(Color.FromArgb(255, 100, 255, 100)),
-            new AvailableColor(Color.FromArgb(255, 255, 255, 255)),
-            new AvailableColor(Color.FromArgb(255, 200, 200, 200)),
-            new AvailableColor(Color.FromArgb(255, 100, 100, 100)),
-            new AvailableColor(Color.FromArgb(255, 50, 50, 50))
+            new AvailableColor(Color.FromRgb(255, 255, 0)),
+            new AvailableColor(Color.FromRgb(255, 200, 100)),
+            new AvailableColor(Color.FromRgb(0, 255, 255)),
+            new AvailableColor(Color.FromRgb(100, 255, 100)),
+            new AvailableColor(Color.FromRgb(255, 255, 255)),
+            new AvailableColor(Color.FromRgb(200, 200, 200)),
+            new AvailableColor(Color.FromRgb(100, 100, 100)),
+            new AvailableColor(Color.FromRgb(50, 50, 50))
         };
 
         private readonly List<GitTreeNode> nodes = new List<GitTreeNode>();

--- a/GitOut/Features/Git/Log/GitTreeNode.cs
+++ b/GitOut/Features/Git/Log/GitTreeNode.cs
@@ -37,6 +37,5 @@ namespace GitOut.Features.Git.Log
 
         public static GitTreeNode WithTopLine(Line top, Color color, bool commit) => new GitTreeNode(top, null, color, commit);
         public static GitTreeNode WithBottomLine(Line bottom, Color color, bool commit) => new GitTreeNode(null, bottom, color, commit);
-
     }
 }

--- a/GitOut/Features/Git/Log/GitTreeNode.cs
+++ b/GitOut/Features/Git/Log/GitTreeNode.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Windows.Media;
+
+namespace GitOut.Features.Git.Log
+{
+    public class GitTreeNode
+    {
+        private const string LinesDoNotMeetError = "lines do not meet";
+        private Line? bottomLayer;
+
+        public GitTreeNode(Line? top, Line? bottom, Color color, bool commit)
+        {
+            Top = top;
+            Bottom = bottom;
+            Color = color;
+            IsCommit = commit;
+        }
+
+        public bool IsCommit { get; }
+
+        public Color Color { get; }
+
+        public Line? Top { get; }
+        public Line? Bottom
+        {
+            get => bottomLayer;
+            set
+            {
+                if (value is Line bottom && Top is Line top && top.Down != bottom.Up)
+                {
+                    throw new ArgumentException(LinesDoNotMeetError);
+                }
+
+                bottomLayer = value;
+            }
+        }
+    }
+}

--- a/GitOut/Features/Git/Log/GitTreeNode.cs
+++ b/GitOut/Features/Git/Log/GitTreeNode.cs
@@ -8,7 +8,7 @@ namespace GitOut.Features.Git.Log
         private const string LinesDoNotMeetError = "lines do not meet";
         private Line? bottomLayer;
 
-        public GitTreeNode(Line? top, Line? bottom, Color color, bool commit)
+        private GitTreeNode(Line? top, Line? bottom, Color color, bool commit)
         {
             Top = top;
             Bottom = bottom;
@@ -34,5 +34,9 @@ namespace GitOut.Features.Git.Log
                 bottomLayer = value;
             }
         }
+
+        public static GitTreeNode WithTopLine(Line top, Color color, bool commit) => new GitTreeNode(top, null, color, commit);
+        public static GitTreeNode WithBottomLine(Line bottom, Color color, bool commit) => new GitTreeNode(null, bottom, color, commit);
+
     }
 }

--- a/GitOut/Features/Git/Log/GitTreeNode.cs
+++ b/GitOut/Features/Git/Log/GitTreeNode.cs
@@ -28,7 +28,7 @@ namespace GitOut.Features.Git.Log
             {
                 if (value is Line bottom && Top is Line top && top.Down != bottom.Up)
                 {
-                    throw new ArgumentException(LinesDoNotMeetError);
+                    throw new ArgumentException(LinesDoNotMeetError, nameof(value));
                 }
 
                 bottomLayer = value;

--- a/GitOut/Features/Git/Log/Line.cs
+++ b/GitOut/Features/Git/Log/Line.cs
@@ -1,0 +1,11 @@
+﻿namespace GitOut.Features.Git.Log
+{
+    public struct Line
+    {
+        public Line(int up, int down)
+            => (Up, Down) = (up, down);
+
+        public int Up { get; }
+        public int Down { get; }
+    }
+}

--- a/GitOut/Features/Git/Log/TreeBuildingLeaf.cs
+++ b/GitOut/Features/Git/Log/TreeBuildingLeaf.cs
@@ -1,0 +1,14 @@
+﻿namespace GitOut.Features.Git.Log
+{
+    public class TreeBuildingLeaf
+    {
+        public TreeBuildingLeaf(GitHistoryEvent? lookingFor, GitTreeNode currentNode)
+        {
+            LookingFor = lookingFor;
+            Current = currentNode;
+        }
+
+        public GitHistoryEvent? LookingFor { get; }
+        public GitTreeNode Current { get; }
+    }
+}

--- a/GitOut/Features/Git/Log/TreeBuildingLeaf.cs
+++ b/GitOut/Features/Git/Log/TreeBuildingLeaf.cs
@@ -2,7 +2,7 @@
 {
     public class TreeBuildingLeaf
     {
-        public TreeBuildingLeaf(GitHistoryEvent? lookingFor, GitTreeNode currentNode)
+        private TreeBuildingLeaf(GitHistoryEvent? lookingFor, GitTreeNode currentNode)
         {
             LookingFor = lookingFor;
             Current = currentNode;
@@ -10,5 +10,7 @@
 
         public GitHistoryEvent? LookingFor { get; }
         public GitTreeNode Current { get; }
+        public static TreeBuildingLeaf WithoutParent(GitTreeNode node) => new TreeBuildingLeaf(null, node);
+        public static TreeBuildingLeaf WithParent(GitHistoryEvent parent, GitTreeNode node) => new TreeBuildingLeaf(parent, node);
     }
 }

--- a/GitOut/Features/Wpf/Converters/ColorToBrushConverter.cs
+++ b/GitOut/Features/Wpf/Converters/ColorToBrushConverter.cs
@@ -12,6 +12,6 @@ namespace GitOut.Features.Wpf.Converters
             => value is Color color ? new SolidColorBrush(color) : DependencyProperty.UnsetValue;
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => throw new NotSupportedException();
+            => Binding.DoNothing;
     }
 }

--- a/GitOut/Features/Wpf/Converters/ColorToBrushConverter.cs
+++ b/GitOut/Features/Wpf/Converters/ColorToBrushConverter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace GitOut.Features.Wpf.Converters
+{
+    public class ColorToBrushConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value is Color color ? new SolidColorBrush(color) : DependencyProperty.UnsetValue;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
draws git commits as dots in a tree, and pushes other content to the right of tree with a margin