### PR TITLE
feature(diff): apply basic syntax highlighting for diffed files

### DIFF
--- a/GitOut/Features/Git/Diff/HunkLine.cs
+++ b/GitOut/Features/Git/Diff/HunkLine.cs
@@ -4,6 +4,8 @@ namespace GitOut.Features.Git.Diff
 {
     public class HunkLine
     {
+        public static readonly HunkLine Empty = new HunkLine(DiffLineType.None, string.Empty, null, null);
+
         private HunkLine(DiffLineType type, string line, int? fromIndex, int? toIndex)
         {
             switch (type)

--- a/GitOut/Features/Text/CSharpSyntaxHighlighter.cs
+++ b/GitOut/Features/Text/CSharpSyntaxHighlighter.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace GitOut.Features.Text
+{
+    public class CSharpSyntaxHighlighter : ISyntaxHighlighter
+    {
+        private static readonly Thickness ZeroThickness = new Thickness(0);
+
+        private static readonly string[] Keywords = new[]
+        {
+            "public",
+            "protected",
+            "private",
+            "internal",
+            "partial",
+            "override",
+            "static",
+            "sealed",
+            "namespace",
+            "using",
+            "readonly",
+            "const",
+            "class",
+            "interface",
+            "struct",
+            "void",
+            "async",
+            "await",
+            "get",
+            "set",
+            "event",
+            "add",
+            "remove",
+            "ref",
+            "out",
+            "new",
+            "is",
+            "this",
+            "params",
+            "lock",
+            "bool",
+            "true",
+            "false",
+            "null",
+            "string",
+            "object",
+            "int",
+            "double",
+            "short",
+            "var",
+            "where"
+        };
+
+        private static readonly string[] ControlKeywords = new[]
+        {
+            "return",
+            "if",
+            "else",
+            "for",
+            "foreach",
+            "in",
+            "while",
+            "do",
+            "switch",
+            "case",
+            "default",
+            "continue",
+            "break",
+            "yield",
+            "try",
+            "catch",
+            "finally",
+            "throw",
+        };
+
+        private static readonly Regex KeywordRegex = new Regex($"\\b({string.Join("|", Keywords)})\\b", RegexOptions.Compiled);
+        private static readonly Regex controlKeywordRegex = new Regex($"\\b({string.Join("|", ControlKeywords)})\\b", RegexOptions.Compiled);
+        private static readonly Regex stringRegex = new Regex("\"(.)+?(?<!\\\\)\"", RegexOptions.Compiled);
+
+        public IEnumerable<Paragraph> Highlight(IEnumerable<string> document, ILineDecorator decorator) => document.Select((line, index) =>
+        {
+            var para = new Paragraph() { Margin = ZeroThickness };
+            para.Inlines.AddRange(Tokenize(line));
+            decorator.Decorate(para, index);
+            return para;
+        });
+
+        private static IEnumerable<Run> Tokenize(string line)
+        {
+            if (line.Length == 0)
+            {
+                yield return new Run();
+            }
+            IReadOnlyCollection<Match> keywordMatch = KeywordRegex.Matches(line);
+            IReadOnlyCollection<Match> controlKeywordMatch = controlKeywordRegex.Matches(line);
+            IReadOnlyCollection<Match> stringMatch = stringRegex.Matches(line);
+
+            // join collections and remove invalid (e.g. keywords in string)
+            IEnumerable<IDecoratedMatch> matches = Join(
+                line.Length,
+                keywordMatch.Select(match => new ColorAppliedMatch(match, CSharpSyntaxHighlighterOptions.KeywordForegroundColor)),
+                controlKeywordMatch.Select(match => new ColorAppliedMatch(match, CSharpSyntaxHighlighterOptions.ControlKeywordForegroundColor)),
+                stringMatch.Select(match => new ColorAppliedMatch(match, CSharpSyntaxHighlighterOptions.StringForegroundColor))
+            );
+            foreach (IDecoratedMatch match in matches)
+            {
+                yield return match.Apply(line);
+            }
+        }
+
+        private static IEnumerable<IDecoratedMatch> Join(int length, params IEnumerable<ColorAppliedMatch>[] collections)
+        {
+            IEnumerable<ColorAppliedMatch> ordered = collections
+                .SelectMany(e => e)
+                .OrderBy(match => match.Index);
+
+            int currentOffset = 0;
+            foreach (ColorAppliedMatch m in ordered)
+            {
+                if (m.Index < currentOffset)
+                {
+                    continue;
+                }
+                if (m.Index > currentOffset)
+                {
+                    yield return new UndecoratedMatch(currentOffset, m.Index);
+                }
+                yield return m;
+                currentOffset = m.Index + m.Length;
+            }
+            if (currentOffset < length)
+            {
+                yield return new UndecoratedMatch(currentOffset, length);
+            }
+        }
+
+        private class UndecoratedMatch : IDecoratedMatch
+        {
+            public UndecoratedMatch(int offset, int endIndex)
+            {
+                Offset = offset;
+                EndIndex = endIndex;
+            }
+
+            public int Offset { get; }
+            public int EndIndex { get; }
+            public Run Apply(string line) => new Run(line[Offset..EndIndex]);
+        }
+
+        private class ColorAppliedMatch : IDecoratedMatch
+        {
+            private readonly Brush color;
+
+            public ColorAppliedMatch(Match match, Brush color)
+            {
+                Index = match.Index;
+                Length = match.Length;
+                this.color = color;
+            }
+
+            public int Index { get; }
+            public int Length { get; }
+
+            public Run Apply(string line) => new Run(line[Index..(Index + Length)])
+            {
+                Foreground = color
+            };
+        }
+    }
+}

--- a/GitOut/Features/Text/CSharpSyntaxHighlighter.cs
+++ b/GitOut/Features/Text/CSharpSyntaxHighlighter.cs
@@ -43,6 +43,8 @@ namespace GitOut.Features.Text
             "this",
             "params",
             "lock",
+            "nameof",
+            "typeof",
             "bool",
             "true",
             "false",

--- a/GitOut/Features/Text/CSharpSyntaxHighlighter.cs
+++ b/GitOut/Features/Text/CSharpSyntaxHighlighter.cs
@@ -81,8 +81,8 @@ namespace GitOut.Features.Text
         };
 
         private static readonly Regex KeywordRegex = new Regex($"\\b({string.Join("|", Keywords)})\\b", RegexOptions.Compiled);
-        private static readonly Regex controlKeywordRegex = new Regex($"\\b({string.Join("|", ControlKeywords)})\\b", RegexOptions.Compiled);
-        private static readonly Regex stringRegex = new Regex("\"(.)+?(?<!\\\\)\"", RegexOptions.Compiled);
+        private static readonly Regex ControlKeywordRegex = new Regex($"\\b({string.Join("|", ControlKeywords)})\\b", RegexOptions.Compiled);
+        private static readonly Regex StringRegex = new Regex("\"(.)+?(?<!\\\\)\"", RegexOptions.Compiled);
 
         public IEnumerable<Paragraph> Highlight(IEnumerable<string> document, ILineDecorator decorator) => document.Select((line, index) =>
         {
@@ -99,8 +99,8 @@ namespace GitOut.Features.Text
                 yield return new Run();
             }
             IReadOnlyCollection<Match> keywordMatch = KeywordRegex.Matches(line);
-            IReadOnlyCollection<Match> controlKeywordMatch = controlKeywordRegex.Matches(line);
-            IReadOnlyCollection<Match> stringMatch = stringRegex.Matches(line);
+            IReadOnlyCollection<Match> controlKeywordMatch = ControlKeywordRegex.Matches(line);
+            IReadOnlyCollection<Match> stringMatch = StringRegex.Matches(line);
 
             // join collections and remove invalid (e.g. keywords in string)
             IEnumerable<IDecoratedMatch> matches = Join(

--- a/GitOut/Features/Text/CSharpSyntaxHighlighterOptions.cs
+++ b/GitOut/Features/Text/CSharpSyntaxHighlighterOptions.cs
@@ -1,0 +1,11 @@
+using System.Windows.Media;
+
+namespace GitOut.Features.Text
+{
+    public static class CSharpSyntaxHighlighterOptions
+    {
+        public static readonly Brush KeywordForegroundColor = new SolidColorBrush(Color.FromRgb(86, 156, 214));
+        public static readonly Brush ControlKeywordForegroundColor = new SolidColorBrush(Color.FromRgb(216, 160, 223));
+        public static readonly Brush StringForegroundColor = Brushes.PeachPuff;
+    }
+}

--- a/GitOut/Features/Text/IDecoratedMatch.cs
+++ b/GitOut/Features/Text/IDecoratedMatch.cs
@@ -1,0 +1,9 @@
+using System.Windows.Documents;
+
+namespace GitOut.Features.Text
+{
+    public interface IDecoratedMatch
+    {
+        Run Apply(string line);
+    }
+}

--- a/GitOut/Features/Text/ILineDecorator.cs
+++ b/GitOut/Features/Text/ILineDecorator.cs
@@ -1,0 +1,9 @@
+using System.Windows.Documents;
+
+namespace GitOut.Features.Text
+{
+    public interface ILineDecorator
+    {
+        void Decorate(Paragraph paragraph, int lineNumber);
+    }
+}

--- a/GitOut/Features/Text/ISyntaxHighlighter.cs
+++ b/GitOut/Features/Text/ISyntaxHighlighter.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Windows.Documents;
+
+namespace GitOut.Features.Text
+{
+    public interface ISyntaxHighlighter
+    {
+        IEnumerable<Paragraph> Highlight(IEnumerable<string> document, ILineDecorator decorator);
+    }
+}

--- a/GitOutTest/Features/Text/CSharpSyntaxHighlighterTest.cs
+++ b/GitOutTest/Features/Text/CSharpSyntaxHighlighterTest.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Documents;
+using Moq;
+using NUnit.Framework;
+
+namespace GitOut.Features.Text
+{
+    public class CSharpSyntaxHighlighterTest
+    {
+        [Test]
+        public void HighlightShouldHighlight()
+        {
+            string[] lines = new[]
+            {
+                "public void Main() {",
+
+            };
+
+            var decorator = new Mock<ILineDecorator>();
+
+            var actor = new CSharpSyntaxHighlighter();
+            IEnumerable<Paragraph> document = actor.Highlight(lines, decorator.Object);
+            Assert.That(document, Is.Not.Null);
+        }
+
+        [Test]
+        public void HighlightShouldFindStrings()
+        {
+            string[] lines = new[]
+            {
+                "\"this is a string\"",
+                "string x = \"a string value\"",
+                "<div class=\"d-flex\" data.attr=\"1\">",
+                "string a = \"escaped \\\"string\\\"\";"
+            };
+            var decorator = new Mock<ILineDecorator>();
+
+            var actor = new CSharpSyntaxHighlighter();
+            IList<Paragraph> document = actor.Highlight(lines, decorator.Object).ToList();
+
+            CollectionAssert.AreEqual(
+                new[] { "this is a string" },
+                document[0].Inlines.OfType<Run>().Where(run => run.Foreground == CSharpSyntaxHighlighterOptions.StringForegroundColor).Select(run => run.Text.Trim('"'))
+            );
+            CollectionAssert.AreEqual(
+                new[] { "a string value" },
+                document[1].Inlines.OfType<Run>().Where(run => run.Foreground == CSharpSyntaxHighlighterOptions.StringForegroundColor).Select(run => run.Text.Trim('"'))
+            );
+            CollectionAssert.AreEqual(
+                new[] { "d-flex", "1" },
+                document[2].Inlines.OfType<Run>().Where(run => run.Foreground == CSharpSyntaxHighlighterOptions.StringForegroundColor).Select(run => run.Text.Trim('"'))
+            );
+            CollectionAssert.AreEqual(
+                new[] { "\"escaped \\\"string\\\"\"" },
+                document[3].Inlines.OfType<Run>().Where(run => run.Foreground == CSharpSyntaxHighlighterOptions.StringForegroundColor).Select(run => run.Text)
+            );
+        }
+
+        [Test]
+        public void HighlightShouldFindKeywords()
+        {
+            string[] lines = new[]
+            {
+                "\"this is a string\"",
+                "string x = \"a string value\"",
+                "var empty = \"\""
+            };
+
+            var decorator = new Mock<ILineDecorator>();
+
+            var actor = new CSharpSyntaxHighlighter();
+            IList<Paragraph> document = actor.Highlight(lines, decorator.Object).ToList();
+
+            Assert.That(((Run)document[1].Inlines.FirstInline).Text, Is.EqualTo("string"));
+            Assert.That(document[1].Inlines.FirstInline.Foreground, Is.EqualTo(CSharpSyntaxHighlighterOptions.KeywordForegroundColor));
+            Assert.That(((Run)document[2].Inlines.FirstInline).Text, Is.EqualTo("var"));
+            Assert.That(document[2].Inlines.FirstInline.Foreground, Is.EqualTo(CSharpSyntaxHighlighterOptions.KeywordForegroundColor));
+        }
+    }
+}


### PR DESCRIPTION
This change highlights every file as it was a csharp file.
We should add more file types later and color each file type separately, with a fundamental mode as fallback.