### PR TITLE
enhancement(shell): back command is now global and subscribed to in NavigationService

### DIFF
--- a/GitOut/Features/Git/Stage/GitStagePage.xaml
+++ b/GitOut/Features/Git/Stage/GitStagePage.xaml
@@ -8,6 +8,7 @@
     xmlns:local="clr-namespace:GitOut.Features.Git.Stage"
     xmlns:converters="clr-namespace:GitOut.Features.Wpf.Converters"
     xmlns:wpf="clr-namespace:GitOut.Features.Wpf"
+    xmlns:wpfcommands="clr-namespace:GitOut.Features.Wpf.ApplicationCommands"
     mc:Ignorable="d" 
     d:DesignHeight="450"
     d:DesignWidth="800"
@@ -76,7 +77,11 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Button Style="{StaticResource MaterialButtonStyle}" Command="{Binding NavigateBackCommand}" ToolTip="Back">
+            <Button
+                Style="{StaticResource MaterialButtonStyle}"
+                Command="{x:Static wpfcommands:Navigate.Back}"
+                ToolTip="Back"
+            >
                 <Path Height="24" Fill="{DynamicResource MaterialForegroundBase}" Data="{StaticResource ArrowLeft}"/>
             </Button>
             <TextBlock Grid.Column="1" Text="Stage" Style="{StaticResource MaterialToolbarHeaderStyle}"/>

--- a/GitOut/Features/Git/Stage/GitStageViewModel.cs
+++ b/GitOut/Features/Git/Stage/GitStageViewModel.cs
@@ -63,7 +63,6 @@ namespace GitOut.Features.Git.Stage
             BindingOperations.EnableCollectionSynchronization(indexFiles, indexFilesLock);
             IndexFiles = CollectionViewSource.GetDefaultView(indexFiles);
 
-            NavigateBackCommand = new CallbackCommand(navigation.Back, navigation.CanGoBack);
             RefreshStatusCommand = new AsyncCallbackCommand(GetRepositoryStatusAsync);
             CommitCommand = new AsyncCallbackCommand(CommitChangesAsync, () => !string.IsNullOrEmpty(CommitMessage) && indexFiles.Count > 0);
             StageFileCommand = new AsyncCallbackCommand<StatusChangeViewModel>(StageFileAsync);
@@ -167,7 +166,6 @@ namespace GitOut.Features.Git.Stage
         public ICollectionView IndexFiles { get; }
         public ICollectionView WorkspaceFiles { get; }
 
-        public ICommand NavigateBackCommand { get; }
         public ICommand RefreshStatusCommand { get; }
         public ICommand AddAllCommand { get; }
         public ICommand StageFileCommand { get; }

--- a/GitOut/Features/Navigation/INavigationService.cs
+++ b/GitOut/Features/Navigation/INavigationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace GitOut.Features.Navigation
 {
@@ -9,8 +9,5 @@ namespace GitOut.Features.Navigation
         T? GetOptions<T>(string pageName) where T : class;
 
         void Navigate(string page, object? options);
-
-        void Back();
-        bool CanGoBack();
     }
 }

--- a/GitOut/Features/Navigation/NavigationService.cs
+++ b/GitOut/Features/Navigation/NavigationService.cs
@@ -61,6 +61,8 @@ namespace GitOut.Features.Navigation
 #pragma warning restore CA1031 // Do not catch general exception types
                 }
             });
+
+            Wpf.ApplicationCommands.Navigate.Back.Add(Back, CanGoBack);
         }
 
         public string? CurrentPage { get; private set; }
@@ -154,6 +156,7 @@ namespace GitOut.Features.Navigation
                         logger.LogInformation(LogEventId.Navigation, "Navigating to control " + pageName);
                         OnNavigationRequested(page);
                         pageStack.Push(new Tuple<ContentControl, string?, IServiceScope>(page, currentTitle, scope));
+                        Wpf.ApplicationCommands.Navigate.Back.RaiseExecuteChanged();
                         CurrentPage = pageName;
                         if (page.DataContext is INavigationListener listener)
                         {

--- a/GitOut/Features/Settings/SettingsPage.xaml
+++ b/GitOut/Features/Settings/SettingsPage.xaml
@@ -8,6 +8,7 @@
     xmlns:staging="clr-namespace:GitOut.Features.Git.Stage"
     xmlns:local="clr-namespace:GitOut.Features.Settings"
     xmlns:themes="clr-namespace:GitOut.Features.Themes"
+    xmlns:wpfcommands="clr-namespace:GitOut.Features.Wpf.ApplicationCommands"
     mc:Ignorable="d"
     d:DataContext="{d:DesignInstance Type=local:SettingsViewModel}"
     d:DesignHeight="450"
@@ -74,7 +75,7 @@
                     Margin="16"
                     HorizontalAlignment="Left"
                 >
-                    <Button Style="{StaticResource NavigateBackButtonStyle}" Command="{Binding NavigateBackCommand}" />
+                    <Button Style="{StaticResource NavigateBackButtonStyle}" Command="{x:Static wpfcommands:Navigate.Back}" />
                 </Grid>
 
                 <ListBox

--- a/GitOut/Features/Settings/SettingsViewModel.cs
+++ b/GitOut/Features/Settings/SettingsViewModel.cs
@@ -33,7 +33,6 @@ namespace GitOut.Features.Settings
 
         public SettingsViewModel(
             ITitleService title,
-            INavigationService navigation,
             ISnackbarService snacks,
             IThemeService themes,
             IGitRepositoryStorage repositories,
@@ -100,7 +99,6 @@ namespace GitOut.Features.Settings
                     themes.ChangeTheme(theme);
                     snacks.ShowSuccess($"Changed theme to {theme.Name}");
                 });
-            NavigateBackCommand = new CallbackCommand(navigation.Back, navigation.CanGoBack);
 
             trimLineEndings = stageOptions.CurrentValue.TrimLineEndings;
             tabTransformText = stageOptions.CurrentValue.TabTransformText;
@@ -155,7 +153,6 @@ namespace GitOut.Features.Settings
         public ICommand SearchRootFolderCommand { get; }
         public ICommand AddRepositoryCommand { get; }
         public ICommand ChangeThemeCommand { get; }
-        public ICommand NavigateBackCommand { get; }
 
         public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/GitOut/Features/Wpf/ApplicationCommands/Navigate.cs
+++ b/GitOut/Features/Wpf/ApplicationCommands/Navigate.cs
@@ -1,0 +1,7 @@
+namespace GitOut.Features.Wpf.ApplicationCommands
+{
+    public static class Navigate
+    {
+        public static CompositeCommand Back { get; } = new CompositeCommand();
+    }
+}

--- a/GitOut/Features/Wpf/NavigatorShell.xaml
+++ b/GitOut/Features/Wpf/NavigatorShell.xaml
@@ -6,6 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:GitOut.Features.Wpf"
     xmlns:converters="clr-namespace:GitOut.Features.Wpf.Converters"
+    xmlns:wpfcommands="clr-namespace:GitOut.Features.Wpf.ApplicationCommands"
     mc:Ignorable="d"
     x:Name="window"
     Title="git out"
@@ -37,7 +38,7 @@
     </WindowChrome.WindowChrome>
     <Window.InputBindings>
         <KeyBinding Key="P" Modifiers="Ctrl" Command="{Binding OpenSettingsCommand}" />
-        <KeyBinding Key="Left" Modifiers="Alt" Command="{Binding NavigateBackCommand}" />
+        <KeyBinding Key="Left" Modifiers="Alt" Command="{x:Static wpfcommands:Navigate.Back}" />
     </Window.InputBindings>
     <Window.Resources>
         <Style x:Key="NavigationToolbarStyle" TargetType="{x:Type Grid}">

--- a/GitOut/Features/Wpf/NavigatorShellViewModel.cs
+++ b/GitOut/Features/Wpf/NavigatorShellViewModel.cs
@@ -40,7 +40,6 @@ namespace GitOut.Features.Wpf
             snack.SnackReceived += (sender, args) => ShowSnackAsync(args.Snack, snacks).ConfigureAwait(false);
 
             CloseCommand = new CallbackCommand(life.StopApplication);
-            NavigateBackCommand = new CallbackCommand(navigation.Back, navigation.CanGoBack);
             OpenSettingsCommand = new NavigateLocalCommand<object>(
                 navigation,
                 typeof(SettingsPage).FullName!,
@@ -54,7 +53,6 @@ namespace GitOut.Features.Wpf
         public ICommand RestoreCommand { get; } = new CallbackCommand<Window>(window => window.WindowState = WindowState.Normal);
         public ICommand ToggleWindowStateCommand { get; } = new CallbackCommand<Window>(window => window.WindowState = window.WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized);
         public ICommand CloseCommand { get; }
-        public ICommand NavigateBackCommand { get; }
 
         public ICommand OpenSettingsCommand { get; }
 


### PR DESCRIPTION
this implementation has some implications.

- the benefit of merging this is that the viewmodel doesn't always have to know all of the commands that the view will execute. If the command is in a "static" context, i.e. independent on any of the viewmodel services or properties it can most likely be a global command instead.
- the consequence of a global command is that someone have to "listen" to the composite command in order for anything to happen. It might be trickier to set up a new service just to trigger a new command.


I think we can merge it and if we need it, we'll use it. Otherwise we can also wait and see if there will be any new usages of it.