### PR TITLE
fix(shell): maximize respect height of active screen

### DIFF
--- a/GitOut/Features/Wpf/NavigatorShell.xaml
+++ b/GitOut/Features/Wpf/NavigatorShell.xaml
@@ -13,7 +13,6 @@
     Width="1280"
     Height="800"
     MinHeight="300"
-    MaxHeight="{x:Static SystemParameters.MaximizedPrimaryScreenHeight}"
     MinWidth="320"
     WindowStyle="None"
     AllowsTransparency="True"

--- a/GitOut/GitOut.csproj
+++ b/GitOut/GitOut.csproj
@@ -7,11 +7,16 @@
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <ApplicationIcon>gitout.ico</ApplicationIcon>
+    <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.422-beta">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 

--- a/GitOut/NativeMethods.txt
+++ b/GitOut/NativeMethods.txt
@@ -1,0 +1,3 @@
+GetMonitorInfo
+MonitorFromWindow
+MINMAXINFO


### PR DESCRIPTION
this pr introduces the prerelease of https://github.com/microsoft/CsWin32 for sourcegenerating pinvoke commands.
the methods that are to be pinvoked are defined in the NativeMethods.txt file in the gitout folder.

we need to be willing to use this and also be aware of for instance [this thread](https://github.com/microsoft/CsWin32/issues/7) if we want to merge this pr
