### PR TITLE
fix(gitlogpage): sets branch color based on incoming/outgoing leaf

### DIFF
--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -23,6 +23,7 @@ namespace GitOut.Features.Git.Log
 
         private readonly List<GitTreeNode> nodes = new();
         private int commitIndex = -1;
+        private int colorIndex = 0;
         private bool isSelected;
 
         public GitTreeEvent(GitHistoryEvent historyEvent) => Event = historyEvent;
@@ -34,7 +35,7 @@ namespace GitOut.Features.Git.Log
         {
             get
             {
-                var commitBrush = new SolidColorBrush(colors[commitIndex % colors.Count].Color);
+                var commitBrush = new SolidColorBrush(colors[colorIndex % colors.Count].Color);
                 commitBrush.Freeze();
                 return commitBrush;
             }
@@ -63,7 +64,7 @@ namespace GitOut.Features.Git.Log
                 if (from == commitIndex)
                 {
                     processedCommit = true;
-
+                    colorIndex = colors.FindIndex(ac => ac.Color == leaf.Current.Color);
                     if (Event.Parent is not null)
                     {
                         leaf.Current.Bottom = new Line(from, to++);
@@ -85,6 +86,7 @@ namespace GitOut.Features.Git.Log
             }
             if (!processedCommit)
             {
+                colorIndex = commitIndex;
                 var node = GitTreeNode.WithBottomLine(new Line(from, to++), GetNextAvailableColor(), true);
                 nodes.Add(node);
                 if (Event.Parent is not null)

--- a/GitOut/Features/Git/Log/GitTreeEvent.cs
+++ b/GitOut/Features/Git/Log/GitTreeEvent.cs
@@ -86,8 +86,10 @@ namespace GitOut.Features.Git.Log
             }
             if (!processedCommit)
             {
-                colorIndex = commitIndex;
-                var node = GitTreeNode.WithBottomLine(new Line(from, to++), GetNextAvailableColor(), true);
+                Color color = GetNextAvailableColor();
+                var node = GitTreeNode.WithBottomLine(new Line(from, to++), color, true);
+                colorIndex = colors.FindIndex(ac => ac.Color == color);
+
                 nodes.Add(node);
                 if (Event.Parent is not null)
                 {


### PR DESCRIPTION
we cannot use the commit index as an indicator of which color is active, since branches can be pushed left or right. So instead, use the color from the leafs that are 'incoming' (if the branch continues) or 'outgoing' (if the branch is new) 

resolves go-115
