### PR TITLE
feature(stage): add --[i]ntent-to-add as a stage command

### DIFF
--- a/GitOut/Features/Git/AddOptions.cs
+++ b/GitOut/Features/Git/AddOptions.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace GitOut.Features.Git
+{
+    public class AddOptions
+    {
+        private AddOptions(bool intentToAdd) => IntentToAdd = intentToAdd;
+
+        public bool IntentToAdd { get; }
+
+        public IEnumerable<string> GetArguments()
+        {
+            if (IntentToAdd)
+            {
+                yield return "--intent-to-add";
+            }
+        }
+
+        public static IAddOptionsBuilder Builder() => new AddOptionsBuilder();
+        public static AddOptions None => new(false);
+
+        private class AddOptionsBuilder : IAddOptionsBuilder
+        {
+            private bool intentToAdd;
+
+            public AddOptions Build() => new(intentToAdd);
+            public IAddOptionsBuilder WithIntent()
+            {
+                intentToAdd = true;
+                return this;
+            }
+        }
+    }
+}

--- a/GitOut/Features/Git/GitModifiedStatusType.cs
+++ b/GitOut/Features/Git/GitModifiedStatusType.cs
@@ -1,4 +1,4 @@
-﻿namespace GitOut.Features.Git
+namespace GitOut.Features.Git
 {
     public enum GitModifiedStatusType
     {
@@ -9,6 +9,7 @@
         Deleted,
         Renamed,
         Copied,
-        UpdatedButUnmerged
+        UpdatedButUnmerged,
+        Untracked
     }
 }

--- a/GitOut/Features/Git/IAddOptionsBuilder.cs
+++ b/GitOut/Features/Git/IAddOptionsBuilder.cs
@@ -1,0 +1,8 @@
+namespace GitOut.Features.Git
+{
+    public interface IAddOptionsBuilder
+    {
+        AddOptions Build();
+        IAddOptionsBuilder WithIntent();
+    }
+}

--- a/GitOut/Features/Git/IGitRepository.cs
+++ b/GitOut/Features/Git/IGitRepository.cs
@@ -30,7 +30,7 @@ namespace GitOut.Features.Git
 
         Task ExecuteAddAllAsync();
         Task ExecuteResetAllAsync();
-        Task ExecuteAddAsync(GitStatusChange change);
+        Task ExecuteAddAsync(GitStatusChange change, AddOptions options);
         Task ExecuteCheckoutAsync(GitStatusChange change);
         Task ExecuteCheckoutBranchAsync(GitBranchName name);
         Task ExecuteResetAsync(GitStatusChange change);

--- a/GitOut/Features/Git/LocalGitRepository.cs
+++ b/GitOut/Features/Git/LocalGitRepository.cs
@@ -372,7 +372,7 @@ namespace GitOut.Features.Git
 
         public Task ExecuteResetAllAsync() => CreateProcess(ProcessOptions.FromArguments("reset HEAD")).ExecuteAsync();
 
-        public Task ExecuteAddAsync(GitStatusChange change) => CreateProcess(ProcessOptions.FromArguments($"add {change.Path}")).ExecuteAsync();
+        public Task ExecuteAddAsync(GitStatusChange change, AddOptions options) => CreateProcess(ProcessOptions.FromArguments($"add {string.Join(" ", options.GetArguments())} -- {change.Path}")).ExecuteAsync();
 
         public Task ExecuteCheckoutAsync(GitStatusChange change) => CreateProcess(ProcessOptions.FromArguments($"checkout HEAD -- {change.Path}")).ExecuteAsync();
 

--- a/GitOut/Features/Git/Stage/GitStagePage.xaml
+++ b/GitOut/Features/Git/Stage/GitStagePage.xaml
@@ -137,6 +137,7 @@
                         <KeyBinding Key="Enter" Command="{Binding StageWorkspaceFilesCommand}" />
                         <KeyBinding Key="R" Command="{Binding ResetWorkspaceFilesCommand}" />
                         <KeyBinding Key="Delete" Command="{Binding ResetWorkspaceFilesCommand}" />
+                        <KeyBinding Key="I" Command="{Binding IntentToAddCommand}" />
                     </ListView.InputBindings>
                 </ListView>
                 <GridSplitter Grid.Row="1" Style="{StaticResource SplitHorizontalStyle}" />

--- a/GitOut/Features/Git/Stage/StatusChangeViewModel.cs
+++ b/GitOut/Features/Git/Stage/StatusChangeViewModel.cs
@@ -15,7 +15,7 @@ namespace GitOut.Features.Git.Stage
             Path = model.Path.ToString();
             if (model.Type == GitStatusChangeType.Untracked)
             {
-                Status = GitModifiedStatusType.Added;
+                Status = GitModifiedStatusType.Untracked;
                 IconResourceKey = "FilePlus";
             }
             else

--- a/GitOut/Features/Git/Stage/StatusToBrushConverter.cs
+++ b/GitOut/Features/Git/Stage/StatusToBrushConverter.cs
@@ -12,6 +12,7 @@ namespace GitOut.Features.Git.Stage
             => value is GitModifiedStatusType status
             ? status switch
             {
+                GitModifiedStatusType.Untracked => (Brush)Application.Current.Resources["Untracked"],
                 GitModifiedStatusType.Added => (Brush)Application.Current.Resources["Added"],
                 GitModifiedStatusType.Deleted => (Brush)Application.Current.Resources["Removed"],
                 GitModifiedStatusType.Modified => (Brush)Application.Current.Resources["Changed"],

--- a/GitOut/Themes/AppTheme.xaml
+++ b/GitOut/Themes/AppTheme.xaml
@@ -17,7 +17,8 @@
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="#FFFFFF"/>
     
     <!-- stage -->
-    <SolidColorBrush x:Key="Added" Color="#FF5AC85A"/>
+    <SolidColorBrush x:Key="Added" Color="#FFF8F85A"/>
     <SolidColorBrush x:Key="Removed" Color="#FFC85A5A"/>
     <SolidColorBrush x:Key="Changed" Color="#FFF8F85A"/>
+    <SolidColorBrush x:Key="Untracked" Color="#FF5AC85A"/>
 </ResourceDictionary>


### PR DESCRIPTION
resolves go-72

noticed some weirdness when:
- add with intent a new file with at least two lines of text
- stage one line
- reset index line to stage
the effect is that the whole file is removed from index and back to untracked. I guess that's intended git logic.

for a quick way to test this pr with the same file, untrack with the command `git restore --staged <filename>` (this is not a command in gitout [yet])