### PR TITLE
feature(shell): add possibility to scale system

### DIFF
--- a/GitOut/Features/Input/MouseWheelAction.cs
+++ b/GitOut/Features/Input/MouseWheelAction.cs
@@ -1,0 +1,9 @@
+namespace GitOut.Features.Input
+{
+    public enum MouseWheelAction
+    {
+        None,
+        MouseWheelUp,
+        MouseWheelDown,
+    }
+}

--- a/GitOut/Features/Input/MouseWheelGesture.cs
+++ b/GitOut/Features/Input/MouseWheelGesture.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel;
+using System.Windows.Input;
+
+namespace GitOut.Features.Input
+{
+    [TypeConverter(typeof(MouseWheelGestureTypeConverter))]
+    public class MouseWheelGesture : MouseGesture
+    {
+        public MouseWheelGesture(MouseWheelAction mouseAction, ModifierKeys modifiers)
+            : base(MouseAction.None, modifiers) => Action = mouseAction;
+
+        public MouseWheelGesture(MouseAction mouseAction, ModifierKeys modifiers)
+            : base(mouseAction, modifiers) { }
+
+        public bool Matches(MouseWheelEventArgs e) =>
+            e.Delta > 0 && Action == MouseWheelAction.MouseWheelUp
+            || e.Delta < 0 && Action == MouseWheelAction.MouseWheelDown;
+
+        public MouseWheelAction Action { get; } = MouseWheelAction.None;
+    }
+}

--- a/GitOut/Features/Input/MouseWheelGestureTypeConverter.cs
+++ b/GitOut/Features/Input/MouseWheelGestureTypeConverter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Windows.Input;
+
+namespace GitOut.Features.Input
+{
+    public class MouseWheelGestureTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) =>
+            sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string str)
+            {
+                string[] parts = str.Split('+', StringSplitOptions.RemoveEmptyEntries);
+                ModifierKeys modifier = ModifierKeys.None;
+                foreach (string part in parts[..^1])
+                {
+                    modifier |= part.ToUpper() switch
+                    {
+                        "CTRL" => ModifierKeys.Control,
+                        "ALT" => ModifierKeys.Alt,
+                        "SHIFT" => ModifierKeys.Shift,
+                        "WIN" => ModifierKeys.Windows,
+                        _ => ModifierKeys.None
+                    };
+                }
+
+                if (Enum.IsDefined(typeof(MouseWheelAction), parts[^1]))
+                {
+                    return new MouseWheelGesture(Enum.Parse<MouseWheelAction>(parts[^1]), modifier);
+                }
+                if (Enum.IsDefined(typeof(MouseAction), parts[^1]))
+                {
+                    return new MouseWheelGesture(Enum.Parse<MouseAction>(parts[^1]), modifier);
+                }
+                throw new NotSupportedException($"Unsupported MouseWheelAction {parts[..^1]}");
+            }
+            throw new NotSupportedException("value is not a string");
+        }
+    }
+}

--- a/GitOut/Features/Wpf/NavigatorShell.xaml
+++ b/GitOut/Features/Wpf/NavigatorShell.xaml
@@ -7,6 +7,7 @@
     xmlns:local="clr-namespace:GitOut.Features.Wpf"
     xmlns:converters="clr-namespace:GitOut.Features.Wpf.Converters"
     xmlns:wpfcommands="clr-namespace:GitOut.Features.Wpf.ApplicationCommands"
+    xmlns:zoom="clr-namespace:GitOut.Features.Wpf.Zoom"
     mc:Ignorable="d"
     x:Name="window"
     Title="{Binding Title, TargetNullValue='git out'}"
@@ -49,7 +50,14 @@
             </Setter>
         </Style>
     </Window.Resources>
-    <Grid x:Name="PART_Root">
+    <Grid
+        x:Name="PART_Root"
+        zoom:ZoomBehavior.ZoomInKeyGesture="Ctrl+Plus"
+        zoom:ZoomBehavior.ZoomOutKeyGesture="Ctrl+Minus"
+        zoom:ZoomBehavior.ZoomResetKeyGesture="Ctrl+D0"
+        zoom:ZoomBehavior.ZoomInMouseWheelGesture="Ctrl+MouseWheelUp"
+        zoom:ZoomBehavior.ZoomOutMouseWheelGesture="Ctrl+MouseWheelDown"
+    >
         <Grid.Resources>
             <converters:WindowStateToVisibilityConverter x:Key="WindowStateToVisibilityConverter"/>
             <Storyboard x:Key="ColoredBorder" x:Shared="true">

--- a/GitOut/Features/Wpf/Zoom/ZoomBehavior.cs
+++ b/GitOut/Features/Wpf/Zoom/ZoomBehavior.cs
@@ -1,0 +1,197 @@
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using GitOut.Features.Input;
+
+namespace GitOut.Features.Wpf.Zoom
+{
+    public static class ZoomBehavior
+    {
+        private const double ScaleStep = .2;
+
+        public static readonly DependencyProperty ZoomInKeyGestureProperty = DependencyProperty.RegisterAttached(
+            "ZoomInKeyGesture",
+            typeof(KeyGesture),
+            typeof(ZoomBehavior),
+            new PropertyMetadata(OnZoomInKeyGestureChanged)
+        );
+
+        public static readonly DependencyProperty ZoomOutKeyGestureProperty = DependencyProperty.RegisterAttached(
+            "ZoomOutKeyGesture",
+            typeof(KeyGesture),
+            typeof(ZoomBehavior),
+            new PropertyMetadata(OnZoomOutKeyGestureChanged)
+        );
+
+        public static readonly DependencyProperty ZoomResetKeyGestureProperty = DependencyProperty.RegisterAttached(
+            "ZoomResetKeyGesture",
+            typeof(KeyGesture),
+            typeof(ZoomBehavior),
+            new PropertyMetadata(OnResetZoomKeyGestureChanged)
+        );
+
+        public static readonly DependencyProperty ZoomInMouseWheelGestureProperty = DependencyProperty.RegisterAttached(
+            "ZoomInMouseWheelGesture",
+            typeof(MouseWheelGesture),
+            typeof(ZoomBehavior),
+            new PropertyMetadata(OnZoomInMouseWheelGestureChanged)
+        );
+
+        public static readonly DependencyProperty ZoomOutMouseWheelGestureProperty = DependencyProperty.RegisterAttached(
+            "ZoomOutMouseWheelGesture",
+            typeof(MouseWheelGesture),
+            typeof(ZoomBehavior),
+            new PropertyMetadata(OnZoomOutMouseWheelGestureChanged)
+        );
+
+        public static KeyGesture? GetZoomInKeyGesture(DependencyObject obj) => (KeyGesture?)obj.GetValue(ZoomInKeyGestureProperty);
+        public static KeyGesture? GetZoomOutKeyGesture(DependencyObject obj) => (KeyGesture?)obj.GetValue(ZoomOutKeyGestureProperty);
+        public static KeyGesture? GetZoomResetKeyGesture(DependencyObject obj) => (KeyGesture?)obj.GetValue(ZoomResetKeyGestureProperty);
+        public static MouseWheelGesture? GetZoomInMouseWheelGesture(DependencyObject obj) => (MouseWheelGesture?)obj.GetValue(ZoomInMouseWheelGestureProperty);
+        public static MouseWheelGesture? GetZoomOutMouseWheelGesture(DependencyObject obj) => (MouseWheelGesture?)obj.GetValue(ZoomOutMouseWheelGestureProperty);
+
+        public static void SetZoomInKeyGesture(DependencyObject obj, KeyGesture? value) => obj.SetValue(ZoomInKeyGestureProperty, value);
+        public static void SetZoomOutKeyGesture(DependencyObject obj, KeyGesture? value) => obj.SetValue(ZoomOutKeyGestureProperty, value);
+        public static void SetZoomResetKeyGesture(DependencyObject obj, KeyGesture? value) => obj.SetValue(ZoomResetKeyGestureProperty, value);
+        public static void SetZoomInMouseWheelGesture(DependencyObject obj, MouseWheelGesture? value) => obj.SetValue(ZoomInMouseWheelGestureProperty, value);
+        public static void SetZoomOutMouseWheelGesture(DependencyObject obj, MouseWheelGesture? value) => obj.SetValue(ZoomOutMouseWheelGestureProperty, value);
+
+        private static void OnZoomInKeyGestureChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement element)
+            {
+                element.PreviewKeyDown -= OnZoomIn;
+                element.PreviewKeyDown += OnZoomIn;
+            }
+        }
+
+        private static void OnZoomOutKeyGestureChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement element)
+            {
+                element.PreviewKeyDown -= OnZoomOut;
+                element.PreviewKeyDown += OnZoomOut;
+            }
+        }
+
+        private static void OnResetZoomKeyGestureChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement element)
+            {
+                element.PreviewKeyDown -= OnResetZoom;
+                element.PreviewKeyDown += OnResetZoom;
+            }
+        }
+
+        private static void OnZoomInMouseWheelGestureChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement element && e.NewValue is MouseWheelGesture mouseWheelGesture)
+            {
+                switch (mouseWheelGesture.Action)
+                {
+                    case MouseWheelAction.MouseWheelDown:
+                    case MouseWheelAction.MouseWheelUp:
+                        element.PreviewMouseWheel -= OnMouseWheelZoomIn;
+                        element.PreviewMouseWheel += OnMouseWheelZoomIn;
+                        return;
+                }
+            }
+        }
+
+        private static void OnZoomOutMouseWheelGestureChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement element && e.NewValue is MouseWheelGesture mouseWheelGesture)
+            {
+                switch (mouseWheelGesture.Action)
+                {
+                    case MouseWheelAction.MouseWheelDown:
+                    case MouseWheelAction.MouseWheelUp:
+                        element.PreviewMouseWheel -= OnMouseWheelZoomOut;
+                        element.PreviewMouseWheel += OnMouseWheelZoomOut;
+                        return;
+                }
+            }
+        }
+
+        private static void OnZoomIn(object sender, KeyEventArgs e)
+        {
+            if (sender is FrameworkElement element
+                && GetZoomInKeyGesture(element) is KeyGesture zoomIn
+                && zoomIn.Key == e.Key
+                && zoomIn.Modifiers == Keyboard.Modifiers)
+            {
+                ScaleTransform transform = GetElementScaleTransform(element);
+                if (transform.ScaleX <= 3)
+                {
+                    transform.ScaleX += ScaleStep;
+                    transform.ScaleY += ScaleStep;
+                }
+            }
+        }
+
+        private static void OnZoomOut(object sender, KeyEventArgs e)
+        {
+            if (sender is FrameworkElement element
+                && GetZoomOutKeyGesture(element) is KeyGesture zoomOut
+                && zoomOut.Key == e.Key
+                && zoomOut.Modifiers == Keyboard.Modifiers)
+            {
+                ScaleTransform transform = GetElementScaleTransform(element);
+                if (transform.ScaleX >= .5)
+                {
+                    transform.ScaleX -= ScaleStep;
+                    transform.ScaleY -= ScaleStep;
+                }
+            }
+        }
+
+        private static void OnResetZoom(object sender, KeyEventArgs e)
+        {
+            if (sender is FrameworkElement element
+                && GetZoomResetKeyGesture(element) is KeyGesture zoomReset
+                && zoomReset.Key == e.Key
+                && zoomReset.Modifiers == Keyboard.Modifiers)
+            {
+                ScaleTransform transform = GetElementScaleTransform(element);
+                transform.ScaleX = 1;
+                transform.ScaleY = 1;
+            }
+        }
+
+        private static void OnMouseWheelZoomIn(object sender, MouseWheelEventArgs e)
+        {
+            if (sender is FrameworkElement element
+                && GetZoomInMouseWheelGesture(element) is MouseWheelGesture zoomIn
+                && zoomIn.Matches(e)
+                && zoomIn.Modifiers == Keyboard.Modifiers)
+            {
+                ScaleTransform transform = GetElementScaleTransform(element);
+                if (transform.ScaleX <= 3)
+                {
+                    transform.ScaleX += ScaleStep;
+                    transform.ScaleY += ScaleStep;
+                }
+            }
+        }
+
+        private static void OnMouseWheelZoomOut(object sender, MouseWheelEventArgs e)
+        {
+            if (sender is FrameworkElement element
+                && GetZoomOutMouseWheelGesture(element) is MouseWheelGesture zoomOut
+                && zoomOut.Matches(e)
+                && zoomOut.Modifiers == Keyboard.Modifiers)
+            {
+                ScaleTransform transform = GetElementScaleTransform(element);
+                if (transform.ScaleX >= .5)
+                {
+                    transform.ScaleX -= ScaleStep;
+                    transform.ScaleY -= ScaleStep;
+                }
+            }
+        }
+
+        private static ScaleTransform GetElementScaleTransform(FrameworkElement element) => (element.LayoutTransform is ScaleTransform scaleTransform)
+            ? scaleTransform
+            : (ScaleTransform)(element.LayoutTransform = new ScaleTransform());
+    }
+}


### PR DESCRIPTION
zoom in and out with <kbd>Ctrl</kbd> <kbd>+</kbd> and <kbd>Ctrl</kbd> <kbd>-</kbd> and reset zoom level with <kbd>Ctrl</kbd> <kbd>0</kbd>
The zoom level isn't persisted, but I did start looking into it. If we do want to persist it, I'm wondering if the feature should be rewritten so that the scale is set from viewmodel (i.e. binding the scale values), or some other kind of service that does it instead. This is at the moment a view only feature.
A second thought is if the zoom level should be set for all views or locally for settings / repo list / stage / log. It's currently global.

Resolves go-73