### PR TITLE
feature(log): keeps selection on log reload

### DIFF
--- a/GitOut/Features/Git/Log/GitLogViewModel.cs
+++ b/GitOut/Features/Git/Log/GitLogViewModel.cs
@@ -373,9 +373,18 @@ namespace GitOut.Features.Git.Log
             IEnumerable<GitTreeEvent> history = BuildTree(tree);
             lock (entriesLock)
             {
+                List<GitCommitId> selected = entries
+                    .Where(e => e.IsSelected)
+                    .Select(e => e.Event.Id)
+                    .ToList();
+
                 entries.Clear();
                 foreach (GitTreeEvent item in history)
                 {
+                    if (selected.Contains(item.Event.Id))
+                    {
+                        item.IsSelected = true;
+                    }
                     entries.Add(item);
                 }
             }


### PR DESCRIPTION
"resolves" #go-133

there are some limitations:
- the window flashes a bit when reloading (due to repainting). not sure if we can use some kind of double buffering here.
- if the selected commit is out-of-view when reloading it _may_ not be selected until scrolled into view. I think it has to due with some distance, not sure where it triggers. Most likely due to some virtualizing.

It was a quick fix which should resolve most of the cases though.