### PR TITLE
feature(repositorylist): enables drop of folders onto repositorylist

### DIFF
--- a/GitOut/Features/Git/RepositoryList/RepositoryListPage.xaml
+++ b/GitOut/Features/Git/RepositoryList/RepositoryListPage.xaml
@@ -7,7 +7,7 @@
     xmlns:git="clr-namespace:GitOut.Features.Git"
     xmlns:text="clr-namespace:GitOut.Features.Text"
     xmlns:local="clr-namespace:GitOut.Features.Git.RepositoryList"
-    mc:Ignorable="d" 
+    mc:Ignorable="d"
     d:DesignHeight="450"
     d:DesignWidth="800"
     x:Name="Root"
@@ -62,6 +62,7 @@
                 QueryMatcher="{StaticResource RepositoryMatcher}"
                 CancelCommand="{Binding ClearCommand}"
                 ItemSelectedCommand="{Binding DataContext.NavigateToLogCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                DropCommand="{Binding DropCommand}"
             >
                 <text:Autocomplete.Style>
                     <Style TargetType="{x:Type text:Autocomplete}">

--- a/GitOut/Features/Git/RepositoryList/RepositoryListViewModel.cs
+++ b/GitOut/Features/Git/RepositoryList/RepositoryListViewModel.cs
@@ -99,9 +99,9 @@ namespace GitOut.Features.Git.RepositoryList
             return action?.Text == approveText ? repository : null;
         }
 
-        private async Task OnDropAsync(System.Windows.DataObject? dataObject)
+        private async Task OnDropAsync(DataObject? dataObject)
         {
-            if (dataObject == null)
+            if (dataObject is null)
             {
                 return;
             }

--- a/GitOut/Features/Git/Storage/GitRepositoryStorage.cs
+++ b/GitOut/Features/Git/Storage/GitRepositoryStorage.cs
@@ -38,6 +38,13 @@ namespace GitOut.Features.Git.Storage
                 .ToArray()
         });
 
+        public void AddRange(IEnumerable<IGitRepository> repositories) => storage.Write(GitStoreOptions.SectionKey, new
+        {
+            Repositories = (options.CurrentValue.Repositories ?? Array.Empty<string>())
+                .Concat(repositories.Select(r => r.WorkingDirectory.Directory))
+                .ToArray()
+        });
+
         public void Remove(IGitRepository repository) => storage.Write(GitStoreOptions.SectionKey, new
         {
             Repositories = (options.CurrentValue.Repositories ?? Array.Empty<string>())

--- a/GitOut/Features/Git/Storage/IGitRepositoryStorage.cs
+++ b/GitOut/Features/Git/Storage/IGitRepositoryStorage.cs
@@ -8,6 +8,7 @@ namespace GitOut.Features.Git.Storage
         IObservable<IEnumerable<IGitRepository>> Repositories { get; }
 
         void Add(IGitRepository repository);
+        void AddRange(IEnumerable<IGitRepository> repositories);
         void Remove(IGitRepository repository);
     }
 }

--- a/GitOut/Features/Text/Autocomplete.xaml
+++ b/GitOut/Features/Text/Autocomplete.xaml
@@ -2,10 +2,11 @@
     x:Class="GitOut.Features.Text.Autocomplete"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:drag="clr-namespace:GitOut.Features.Wpf.DragDrop"
     xmlns:local="clr-namespace:GitOut.Features.Text"
-    mc:Ignorable="d" 
+    mc:Ignorable="d"
 >
     <Grid>
         <Grid.RowDefinitions>
@@ -42,24 +43,31 @@
                 </TextBox.InputBindings>
             </TextBox>
         </Grid>
-        <ListView
+        <AdornerDecorator
             Grid.Row="1"
-            x:Name="RecordsList"
-            Style="{StaticResource MaterialListStyle}"
-            ItemsSource="{Binding Local, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"
-            SelectedIndex="{Binding SelectedIndex, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"
         >
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Button
-                        Style="{StaticResource ListViewItemButtonStyle}"
-                        Command="{Binding OpenRecordCommand, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"
-                        CommandParameter="{Binding}"
-                    >
-                        <ContentPresenter ContentTemplate="{Binding ItemTemplate, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"/>
-                    </Button>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+            <ListView
+                x:Name="RecordsList"
+                AllowDrop="True"
+                drag:DragDropBehavior.DropCommand="{Binding DropCommand, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"
+                drag:DragDropBehavior.UseAdorner="True"
+                drag:DragDropBehavior.AdornerStrokeBrush="{StaticResource MaterialBackgroundHover}"
+                Style="{StaticResource MaterialListStyle}"
+                ItemsSource="{Binding Local, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"
+                SelectedIndex="{Binding SelectedIndex, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"
+            >
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <Button
+                            Style="{StaticResource ListViewItemButtonStyle}"
+                            Command="{Binding OpenRecordCommand, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"
+                            CommandParameter="{Binding}"
+                        >
+                            <ContentPresenter ContentTemplate="{Binding ItemTemplate, RelativeSource={RelativeSource AncestorType={x:Type local:Autocomplete}}}"/>
+                        </Button>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </AdornerDecorator>
     </Grid>
 </UserControl>

--- a/GitOut/Features/Text/Autocomplete.xaml.cs
+++ b/GitOut/Features/Text/Autocomplete.xaml.cs
@@ -28,6 +28,12 @@ namespace GitOut.Features.Text
             typeof(Autocomplete)
         );
 
+        public static readonly DependencyProperty DropCommandProperty = DependencyProperty.Register(
+            nameof(DropCommand),
+            typeof(ICommand),
+            typeof(Autocomplete)
+        );
+
         public static readonly DependencyProperty HeaderProperty = DependencyProperty.Register(
             nameof(Header),
             typeof(string),
@@ -137,6 +143,12 @@ namespace GitOut.Features.Text
         {
             get => (ICommand)GetValue(ItemSelectedCommandProperty);
             set => SetValue(ItemSelectedCommandProperty, value);
+        }
+
+        public ICommand DropCommand
+        {
+            get => (ICommand)GetValue(DropCommandProperty);
+            set => SetValue(DropCommandProperty, value);
         }
 
         public string Header

--- a/GitOut/Features/Wpf/DragDrop/DragDropBehavior.cs
+++ b/GitOut/Features/Wpf/DragDrop/DragDropBehavior.cs
@@ -40,27 +40,24 @@ namespace GitOut.Features.Wpf.DragDrop
 
         private static void OnUseAdornerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (d is not FrameworkElement element)
+            if (d is FrameworkElement element)
             {
-                return;
-            }
-            bool useAdorner = (bool)e.NewValue;
-            if (useAdorner)
-            {
-                var layer = AdornerLayer.GetAdornerLayer(element);
-                layer?.Add(new DropAdorner(element, data => HasDirectory(data) ? "Drop folder here" : "Only accepts folders"));
+                bool useAdorner = (bool)e.NewValue;
+                if (useAdorner)
+                {
+                    var layer = AdornerLayer.GetAdornerLayer(element);
+                    layer?.Add(new DropAdorner(element, data => HasDirectory(data) ? "Drop folder here" : "Only accepts folders"));
+                }
             }
         }
 
         private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (d is not FrameworkElement element)
+            if (d is FrameworkElement element)
             {
-                return;
+                element.Drop -= OnDrop;
+                element.Drop += OnDrop;
             }
-
-            element.Drop -= OnDrop;
-            element.Drop += OnDrop;
         }
 
         private static void OnDrop(object sender, DragEventArgs e)

--- a/GitOut/Features/Wpf/DragDrop/DragDropBehavior.cs
+++ b/GitOut/Features/Wpf/DragDrop/DragDropBehavior.cs
@@ -1,0 +1,101 @@
+using System.Collections.Specialized;
+using System.IO;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace GitOut.Features.Wpf.DragDrop
+{
+    public static class DragDropBehavior
+    {
+        public static readonly DependencyProperty DropCommandProperty = DependencyProperty.RegisterAttached(
+            "DropCommand",
+            typeof(ICommand),
+            typeof(DragDropBehavior),
+            new PropertyMetadata(OnCommandChanged)
+        );
+
+        public static readonly DependencyProperty UseAdornerProperty = DependencyProperty.RegisterAttached(
+            "UseAdorner",
+            typeof(bool),
+            typeof(DragDropBehavior),
+            new PropertyMetadata(OnUseAdornerChanged)
+        );
+
+        public static readonly DependencyProperty AdornerStrokeBrushProperty = DependencyProperty.RegisterAttached(
+            "AdornerStrokeBrush",
+            typeof(Brush),
+            typeof(DragDropBehavior),
+            new PropertyMetadata(Brushes.White)
+        );
+
+        public static bool GetUseAdorner(DependencyObject obj) => (bool)obj.GetValue(UseAdornerProperty);
+        public static ICommand GetDropCommand(DependencyObject obj) => (ICommand)obj.GetValue(DropCommandProperty);
+        public static Brush GetAdornerStrokeBrush(DependencyObject obj) => (Brush)obj.GetValue(AdornerStrokeBrushProperty);
+
+        public static void SetUseAdorner(DependencyObject obj, bool value) => obj.SetValue(UseAdornerProperty, value);
+        public static void SetDropCommand(DependencyObject obj, ICommand value) => obj.SetValue(DropCommandProperty, value);
+        public static void SetAdornerStrokeBrush(DependencyObject obj, Brush value) => obj.SetValue(AdornerStrokeBrushProperty, value);
+
+        private static void OnUseAdornerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not FrameworkElement element)
+            {
+                return;
+            }
+            bool useAdorner = (bool)e.NewValue;
+            if (useAdorner)
+            {
+                var layer = AdornerLayer.GetAdornerLayer(element);
+                layer?.Add(new DropAdorner(element, data => HasDirectory(data) ? "Drop folder here" : "Only accepts folders"));
+            }
+        }
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not FrameworkElement element)
+            {
+                return;
+            }
+
+            element.Drop -= OnDrop;
+            element.Drop += OnDrop;
+        }
+
+        private static void OnDrop(object sender, DragEventArgs e)
+        {
+            if (sender is FrameworkElement element
+                && HasDirectory(e.Data)
+                && GetDropCommand(element) is ICommand command
+                && command.CanExecute(e.Data)
+            )
+            {
+                command.Execute(e.Data);
+            }
+        }
+
+        private static bool HasDirectory(IDataObject dataObject)
+        {
+            if (dataObject is not DataObject data)
+            {
+                return false;
+            }
+
+            StringCollection fileDropList = data.GetFileDropList();
+            if (fileDropList.Count == 0)
+            {
+                return false;
+            }
+
+            string? firstFile = fileDropList[0];
+            if (firstFile is null)
+            {
+                return false;
+            }
+
+            FileAttributes attributes = File.GetAttributes(firstFile);
+            return attributes.HasFlag(FileAttributes.Directory);
+        }
+    }
+}

--- a/GitOut/Features/Wpf/DragDrop/DropAdorner.cs
+++ b/GitOut/Features/Wpf/DragDrop/DropAdorner.cs
@@ -8,18 +8,18 @@ namespace GitOut.Features.Wpf.DragDrop
 {
     public class DropAdorner : Adorner
     {
-        private readonly Func<IDataObject, string> adornerText;
+        private readonly Func<IDataObject, string> textSelector;
 
         private bool isDragging;
         private string textToRender = string.Empty;
 
-        public DropAdorner(UIElement adornedElement, Func<IDataObject, string> adornerText) : base(adornedElement)
+        public DropAdorner(UIElement adornedElement, Func<IDataObject, string> textSelector) : base(adornedElement)
         {
             IsHitTestVisible = false;
             adornedElement.DragEnter += OnAdornedElementDragEnter;
             adornedElement.DragLeave += OnAdornedElementDragLeave;
             adornedElement.Drop += OnAdornedElementDrop;
-            this.adornerText = adornerText;
+            this.textSelector = textSelector;
         }
 
         protected override void OnRender(DrawingContext drawingContext)
@@ -31,15 +31,15 @@ namespace GitOut.Features.Wpf.DragDrop
 
             Rect adornedElementRect = new(AdornedElement.RenderSize);
             Brush? brush = DragDropBehavior.GetAdornerStrokeBrush(AdornedElement);
-            Pen renderPen = new(brush, 5) { DashStyle = new DashStyle(new[] { 4d, 4 }, 0) };
+            Pen renderPen = new(brush, 3) { DashStyle = new DashStyle(new[] { 4d, 4 }, 0) };
 
-            drawingContext.DrawRoundedRectangle(Brushes.Transparent, renderPen, adornedElementRect, 10, 10);
+            drawingContext.DrawRectangle(Brushes.Transparent, renderPen, adornedElementRect);
 
             var textblock = new FormattedText(
                 textToRender,
                 CultureInfo.InvariantCulture,
                 FlowDirection.LeftToRight,
-                new Typeface(new FontFamily("Segoe UI"),
+                new Typeface(new FontFamily("Roboto"),
                 FontStyles.Italic,
                 FontWeights.Normal,
                 FontStretches.Normal),
@@ -72,7 +72,7 @@ namespace GitOut.Features.Wpf.DragDrop
             }
 
             isDragging = true;
-            textToRender = adornerText(e.Data);
+            textToRender = textSelector(e.Data);
 
             base.OnDragEnter(e);
             InvalidateVisual();

--- a/GitOut/Features/Wpf/DragDrop/DropAdorner.cs
+++ b/GitOut/Features/Wpf/DragDrop/DropAdorner.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace GitOut.Features.Wpf.DragDrop
+{
+    public class DropAdorner : Adorner
+    {
+        private readonly Func<IDataObject, string> adornerText;
+
+        private bool isDragging;
+        private string textToRender = string.Empty;
+
+        public DropAdorner(UIElement adornedElement, Func<IDataObject, string> adornerText) : base(adornedElement)
+        {
+            IsHitTestVisible = false;
+            adornedElement.DragEnter += OnAdornedElementDragEnter;
+            adornedElement.DragLeave += OnAdornedElementDragLeave;
+            adornedElement.Drop += OnAdornedElementDrop;
+            this.adornerText = adornerText;
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            if (!isDragging)
+            {
+                return;
+            }
+
+            Rect adornedElementRect = new(AdornedElement.RenderSize);
+            Brush? brush = DragDropBehavior.GetAdornerStrokeBrush(AdornedElement);
+            Pen renderPen = new(brush, 5) { DashStyle = new DashStyle(new[] { 4d, 4 }, 0) };
+
+            drawingContext.DrawRoundedRectangle(Brushes.Transparent, renderPen, adornedElementRect, 10, 10);
+
+            var textblock = new FormattedText(
+                textToRender,
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(new FontFamily("Segoe UI"),
+                FontStyles.Italic,
+                FontWeights.Normal,
+                FontStretches.Normal),
+                48,
+                brush,
+                1
+            );
+
+            var textLocation = new Point(adornedElementRect.Width / 2 - textblock.WidthIncludingTrailingWhitespace / 2, adornedElementRect.Height / 2 - textblock.Height);
+            drawingContext.DrawText(textblock, textLocation);
+        }
+
+        private void OnAdornedElementDrop(object sender, DragEventArgs e)
+        {
+            isDragging = false;
+            InvalidateVisual();
+        }
+
+        private void OnAdornedElementDragLeave(object sender, DragEventArgs e)
+        {
+            isDragging = false;
+            InvalidateVisual();
+        }
+
+        private void OnAdornedElementDragEnter(object sender, DragEventArgs e)
+        {
+            if (isDragging)
+            {
+                return;
+            }
+
+            isDragging = true;
+            textToRender = adornerText(e.Data);
+
+            base.OnDragEnter(e);
+            InvalidateVisual();
+        }
+    }
+}


### PR DESCRIPTION
resolves go-62 

allows dropping folder(s) onto the repository list. If something else is dropped, no action is taken. 

running Add directly after each other didn't trigger OnChange between calls, so AddRange is a work around more than a convenience :)

tried to keep dropadowner as independent as possible but it's still a bit.. static, but I figure if we implement more drop behaviors it will change anyway, so didn't spend to much time on it.

