### PR TITLE
fix(repository): add propertychanged event to SortedObservableCollection

### DIFF
--- a/GitOut/Features/Collections/SortedObservableCollection.cs
+++ b/GitOut/Features/Collections/SortedObservableCollection.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace GitOut.Features.Collections
 {
-    public class SortedObservableCollection<T> : ICollection<T>, IReadOnlyCollection<T>, INotifyCollectionChanged
+    public class SortedObservableCollection<T> : ICollection<T>, IReadOnlyCollection<T>, INotifyCollectionChanged, INotifyPropertyChanged
     {
         private readonly Func<T, T, int> comparer;
         private readonly IList<T> backingCollection = new List<T>();
@@ -27,6 +28,7 @@ namespace GitOut.Features.Collections
         public T this[int index] => backingCollection[index];
 
         public event NotifyCollectionChangedEventHandler? CollectionChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         public void Add(T item)
         {
@@ -63,6 +65,7 @@ namespace GitOut.Features.Collections
             T item = backingCollection[index];
             backingCollection.RemoveAt(index);
             CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
         }
 
         public void CopyTo(T[] array, int arrayIndex) => backingCollection.CopyTo(array, arrayIndex);
@@ -73,6 +76,7 @@ namespace GitOut.Features.Collections
         {
             backingCollection.Insert(index, item);
             CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
         }
 
         private int FindSortedIndex(T item)

--- a/GitOut/Features/Git/RepositoryList/RepositoryListPage.xaml
+++ b/GitOut/Features/Git/RepositoryList/RepositoryListPage.xaml
@@ -8,6 +8,7 @@
     xmlns:text="clr-namespace:GitOut.Features.Text"
     xmlns:local="clr-namespace:GitOut.Features.Git.RepositoryList"
     mc:Ignorable="d"
+    d:DataContext="{d:DesignInstance Type={x:Type local:RepositoryListViewModel}}"
     d:DesignHeight="450"
     d:DesignWidth="800"
     x:Name="Root"


### PR DESCRIPTION
Fire PropertyChanged event when Count property has been updated
this resolves go-166 because a trigger was listening on changes for the Count property rather than CollectionChanged