### PR TITLE
fix(git): set encoding of standard output to UTF-8 for all command line processes

### DIFF
--- a/GitOut/Features/Git/Diagnostics/GitProcess.cs
+++ b/GitOut/Features/Git/Diagnostics/GitProcess.cs
@@ -152,6 +152,7 @@ namespace GitOut.Features.Git.Diagnostics
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = CommandLineExecutable,
+                    StandardOutputEncoding = Encoding.UTF8,
                     Arguments = arguments.Arguments,
                     RedirectStandardError = true,
                     RedirectStandardOutput = true,


### PR DESCRIPTION
accented characters are now read properly when running e.g. git log