### PR TITLE
fix(settings): bind add command to the correct place

### DIFF
--- a/GitOut/Features/Settings/SettingsPage.xaml
+++ b/GitOut/Features/Settings/SettingsPage.xaml
@@ -146,7 +146,7 @@
                                                 >
                                                     <Button
                                                         Style="{StaticResource MaterialButtonStyle}"
-                                                        Command="{Binding DataContext.AddRepositoryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                        Command="{Binding DataContext.CurrentContent.AddRepositoryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                         CommandParameter="{Binding}"
                                                         Content="ADD"
                                                     />


### PR DESCRIPTION
fixes [go-94](https://cade.myjetbrains.com/issue/go-94/add-button-does-not-add-repository-to-repository-list)