### PR TITLE
fix(log): allow parenthesis in branch names

### DIFF
--- a/GitOut/Features/Git/GitBranchName.cs
+++ b/GitOut/Features/Git/GitBranchName.cs
@@ -8,7 +8,7 @@ namespace GitOut.Features.Git
         private const string LocalBranchType = "heads";
         private const string RemoteBranchType = "remotes";
 
-        private static readonly Regex ValidBranchName = new("^[\\w\\d](?:[\\w\\d-+@&\\/\\{}.]+)(?<![\\/\\.])$");
+        private static readonly Regex ValidBranchName = new("^[\\w\\d](?:[\\w\\d\\-+@&\\/\\{}.\\(\\)]+)(?<![\\/\\.])$");
         private GitBranchName(string type, string name)
         {
             if (name.Length <= 1)

--- a/GitOutTest/Features/Git/GitBranchNameTest.cs
+++ b/GitOutTest/Features/Git/GitBranchNameTest.cs
@@ -23,6 +23,7 @@ namespace GitOut.Features.Git
         [TestCase("feature_something")]
         [TestCase("some-&-thing")]
         [TestCase("some@name")]
+        [TestCase("wip(test)")]
         public void CreateLocalShouldAllowValidNames(string input)
         {
             bool isValid = GitBranchName.IsValid(input);


### PR DESCRIPTION
allows parenthesis in branch names

using parenthesis in branch names ain't pretty, but it is allowed. 

Also escaped the - sign, since regex101 interpreted it as a range character.