### PR TITLE
feature(stage): only reset workspace changes when resetting workspace files

### DIFF
--- a/GitOut/Features/Git/IGitRepository.cs
+++ b/GitOut/Features/Git/IGitRepository.cs
@@ -43,5 +43,6 @@ namespace GitOut.Features.Git
         Task RestoreAsync(GitStatusChange change);
         Task ApplyAsync(GitPatch patch);
         Task CommitAsync(GitCommitOptions options);
+        Task RestoreWorkspaceAsync(GitStatusChange change);
     }
 }

--- a/GitOut/Features/Git/LocalGitRepository.cs
+++ b/GitOut/Features/Git/LocalGitRepository.cs
@@ -436,6 +436,8 @@ namespace GitOut.Features.Git
             return CreateProcess(ProcessOptions.FromArguments(argumentsBuilder.ToString())).ExecuteAsync();
         }
 
+        public Task RestoreWorkspaceAsync(GitStatusChange change) => CreateProcess(ProcessOptions.FromArguments($"restore -- {change.Path}")).ExecuteAsync();
+
         public Task ApplyAsync(GitPatch patch)
         {
             var argumentsBuilder = new StringBuilder("apply --ignore-whitespace");

--- a/GitOut/Features/Git/Stage/GitStageViewModel.cs
+++ b/GitOut/Features/Git/Stage/GitStageViewModel.cs
@@ -575,7 +575,7 @@ namespace GitOut.Features.Git.Stage
                             await DeleteFileSnackAsync(model.FullPath).ConfigureAwait(false);
                             break;
                         default:
-                            await Repository.CheckoutAsync(model.Model).ConfigureAwait(false);
+                            await Repository.RestoreWorkspaceAsync(model.Model).ConfigureAwait(false);
                             break;
                     }
                 }


### PR DESCRIPTION
instead of using checkout to reset file changes in stage view, use `git restore -- <file>` to only reset the workspace changes

Resolves go141:

### Steps to reproduce

- Open stage
- Select file and stage a selection
- Reset file from workspace file list

### Actual behavior

The old file is checked out, and staged changes are also removed
### Expected behavior

Only the changes that are not staged should be reset