### PR TITLE
fix(log): handle file type Commit (e.g. worktree folders) when diffing commits

### DIFF
--- a/GitOut/Features/Git/Diff/GitDiffFileEntry.cs
+++ b/GitOut/Features/Git/Diff/GitDiffFileEntry.cs
@@ -63,6 +63,7 @@ public class GitDiffFileEntry
         {
             "100" => GitFileType.Blob,
             "040" => GitFileType.Tree,
+            "160" => GitFileType.Commit,
             _ => GitFileType.None,
         };
 

--- a/GitOut/Features/Git/Files/GitFileEntryViewModelFactory.cs
+++ b/GitOut/Features/Git/Files/GitFileEntryViewModelFactory.cs
@@ -101,15 +101,10 @@ public static class GitFileEntryViewModelFactory
             GitDiffFileEntry entry in repository.ListDiffChangesAsync(diff, root, builder.Build())
         )
         {
-            IGitFileEntryViewModel viewmodel = entry.FileType switch
+            if (entry.FileType == GitFileType.Blob)
             {
-                GitFileType.Blob => GitFileViewModel.RelativeDifference(repository, entry, options),
-                _ => throw new ArgumentOutOfRangeException(
-                    $"Cannot create viewmodel for invalid type {entry.FileType}",
-                    nameof(entry)
-                ),
-            };
-            yield return viewmodel;
+                yield return GitFileViewModel.RelativeDifference(repository, entry, options);
+            }
         }
     }
 }

--- a/GitOut/Features/Git/GitFileType.cs
+++ b/GitOut/Features/Git/GitFileType.cs
@@ -5,4 +5,5 @@ public enum GitFileType
     None,
     Tree,
     Blob,
+    Commit,
 }

--- a/GitOut/Features/Git/Log/GitLogViewModel.cs
+++ b/GitOut/Features/Git/Log/GitLogViewModel.cs
@@ -385,7 +385,7 @@ public class GitLogViewModel : INotifyPropertyChanged, INavigationListener, INav
                 updateStageOptions.Update(snap => snap.IgnoreWhitespace = value);
                 if (SelectedContext is not null)
                 {
-                    SelectedContext = LogEntriesViewModel.CreateContext<GitHistoryEvent>(
+                    SelectedContext = LogEntriesViewModel.CreateContext(
                         selectedLogEntries.Count > 0
                             ? selectedLogEntries.Select(vm => vm.Event).ToList()
                             : selectedStashEntries.Select(vm => (GitHistoryEvent)vm.Event).ToList(),


### PR DESCRIPTION
If e.g. a stash contained a worktree folder gitout would fail and show an empty list. This change handles the commit type and ignores it when diffing file list.