### PR TITLE
feature(settings|log): set log revision modes from settings

### DIFF
--- a/GitOut/App.xaml.cs
+++ b/GitOut/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using GitOut.Features.Git;
+using GitOut.Features.Git.Log;
 using GitOut.Features.Git.RepositoryList;
 using GitOut.Features.Git.Stage;
 using GitOut.Features.Git.Storage;
@@ -110,6 +111,9 @@ public partial class App : Application
         services
             .AddWritableOptions<GitStageOptions>()
             .Bind(context.Configuration, GitStageOptions.SectionKey);
+        services
+            .AddWritableOptions<GitLogOptions>()
+            .Bind(context.Configuration, GitLogOptions.SectionKey);
         services.AddLogging();
 
         services.AddHostedService<Bootstrap>();

--- a/GitOut/Features/Git/Log/GitLogOptions.cs
+++ b/GitOut/Features/Git/Log/GitLogOptions.cs
@@ -1,0 +1,12 @@
+namespace GitOut.Features.Git.Log;
+
+public sealed record GitLogOptions
+{
+    public const string SectionKey = "log";
+
+    public LogRevisionViewMode DefaultSingleRevisionViewMode { get; set; } =
+        LogRevisionViewMode.DiffInline;
+
+    public LogRevisionViewMode DefaultMultiRevisionViewMode { get; set; } =
+        LogRevisionViewMode.DiffInline;
+}

--- a/GitOut/Features/Git/Log/GitLogViewModel.cs
+++ b/GitOut/Features/Git/Log/GitLogViewModel.cs
@@ -56,6 +56,7 @@ public class GitLogViewModel : INotifyPropertyChanged, INavigationListener, INav
     private readonly IRepositoryWatcher repositoryWatcher;
     private readonly GitRepositoryMonitor monitor;
     private readonly IDisposable settingsMonitorHandle;
+    private readonly IDisposable logSettingsMonitorHandle;
 
     private readonly ICommand createStashBranchCommand;
 
@@ -72,7 +73,7 @@ public class GitLogViewModel : INotifyPropertyChanged, INavigationListener, INav
     private bool isCheckoutBranchVisible;
     private LogViewMode viewMode = LogViewMode.None;
 
-    private LogRevisionViewMode revisionViewMode = LogRevisionViewMode.CurrentRevision;
+    private LogRevisionViewMode revisionViewMode;
     private LogEntriesViewModel? selectedContext;
 
     private string? checkoutBranchName;
@@ -87,17 +88,38 @@ public class GitLogViewModel : INotifyPropertyChanged, INavigationListener, INav
         IGitRepositoryWatcherProvider watchProvider,
         ISnackbarService snack,
         IOptionsMonitor<GitStageOptions> stagingOptions,
-        IOptionsWriter<GitStageOptions> updateStageOptions
+        IOptionsWriter<GitStageOptions> updateStageOptions,
+        IOptionsMonitor<GitLogOptions> logOptions
     )
     {
         this.snack = snack;
         this.updateStageOptions = updateStageOptions;
         showSpacesAsDots = stagingOptions.CurrentValue.ShowSpacesAsDots;
         ignoreWhitespace = stagingOptions.CurrentValue.IgnoreWhitespace;
+        revisionViewMode = logOptions.CurrentValue.DefaultSingleRevisionViewMode;
         settingsMonitorHandle = stagingOptions.OnChange(options =>
         {
             SetProperty(ref showSpacesAsDots, options.ShowSpacesAsDots, nameof(ShowSpacesAsDots));
             SetProperty(ref ignoreWhitespace, options.IgnoreWhitespace, nameof(IgnoreWhitespace));
+        });
+        logSettingsMonitorHandle = logOptions.OnChange(options =>
+        {
+            if (selectedLogEntries.Count < 2)
+            {
+                SetProperty(
+                    ref revisionViewMode,
+                    options.DefaultSingleRevisionViewMode,
+                    nameof(RevisionViewMode)
+                );
+            }
+            else
+            {
+                SetProperty(
+                    ref revisionViewMode,
+                    options.DefaultMultiRevisionViewMode,
+                    nameof(RevisionViewMode)
+                );
+            }
         });
         GitLogPageOptions options =
             navigation.GetOptions<GitLogPageOptions>(typeof(GitLogPage).FullName!)
@@ -145,10 +167,10 @@ public class GitLogViewModel : INotifyPropertyChanged, INavigationListener, INav
                 ignoreWhitespace ? DiffOptions.Builder().IgnoreAllSpace().Build() : null
             );
             ViewMode = SelectedContext is null ? LogViewMode.None : LogViewMode.Files;
-            if (selectedLogEntries.Count >= 2)
-            {
-                RevisionViewMode = LogRevisionViewMode.Diff;
-            }
+            RevisionViewMode =
+                selectedLogEntries.Count < 2
+                    ? logOptions.CurrentValue.DefaultSingleRevisionViewMode
+                    : logOptions.CurrentValue.DefaultMultiRevisionViewMode;
             UpdateHighlights();
         };
         selectedStashEntries.CollectionChanged += (sender, args) =>
@@ -573,6 +595,7 @@ public class GitLogViewModel : INotifyPropertyChanged, INavigationListener, INav
                 repositoryWatcher.Dispose();
                 monitor.LogChanged -= OnLogChanged;
                 settingsMonitorHandle.Dispose();
+                logSettingsMonitorHandle.Dispose();
                 break;
             case NavigationType.Deactivated:
                 repositoryWatcher.EnableRaisingEvents = true;

--- a/GitOut/Features/Settings/GeneralSettingsViewModel.cs
+++ b/GitOut/Features/Settings/GeneralSettingsViewModel.cs
@@ -10,6 +10,7 @@ using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using GitOut.Features.Git;
+using GitOut.Features.Git.Log;
 using GitOut.Features.Git.Stage;
 using GitOut.Features.Git.Storage;
 using GitOut.Features.IO;
@@ -25,11 +26,15 @@ namespace GitOut.Features.Settings;
 public sealed class GeneralSettingsViewModel : INotifyPropertyChanged, IDisposable
 {
     private readonly IOptionsWriter<GitStageOptions> storage;
+    private readonly IOptionsWriter<GitLogOptions> logStorage;
     private readonly IDisposable unsubscribeOptions;
+    private readonly IDisposable unsubscribeLogOptions;
     private bool useTransparentBackground = true;
     private bool trimLineEndings;
     private bool showSpacesAsDots;
     private string tabTransformText;
+    private LogRevisionViewMode defaultSingleRevisionViewMode;
+    private LogRevisionViewMode defaultMultiRevisionViewMode;
 
     public GeneralSettingsViewModel(
         ISnackbarService snacks,
@@ -37,10 +42,13 @@ public sealed class GeneralSettingsViewModel : INotifyPropertyChanged, IDisposab
         IGitRepositoryStorage repositories,
         IGitRepositoryFactory gitFactory,
         IOptionsMonitor<GitStageOptions> stageOptions,
-        IOptionsWriter<GitStageOptions> storage
+        IOptionsWriter<GitStageOptions> storage,
+        IOptionsMonitor<GitLogOptions> logOptions,
+        IOptionsWriter<GitLogOptions> logStorage
     )
     {
         this.storage = storage;
+        this.logStorage = logStorage;
         var validPaths = new ObservableCollection<ValidGitRepositoryPathViewModel>();
         ValidRepositoryPaths = CollectionViewSource.GetDefaultView(validPaths);
 
@@ -108,6 +116,22 @@ public sealed class GeneralSettingsViewModel : INotifyPropertyChanged, IDisposab
             SetProperty(ref tabTransformText, value.TabTransformText, nameof(TabTransformText));
             SetProperty(ref trimLineEndings, value.TrimLineEndings, nameof(TrimLineEndings));
         });
+
+        defaultSingleRevisionViewMode = logOptions.CurrentValue.DefaultSingleRevisionViewMode;
+        defaultMultiRevisionViewMode = logOptions.CurrentValue.DefaultMultiRevisionViewMode;
+        unsubscribeLogOptions = logOptions.OnChange(value =>
+        {
+            SetProperty(
+                ref defaultSingleRevisionViewMode,
+                value.DefaultSingleRevisionViewMode,
+                nameof(DefaultSingleRevisionViewMode)
+            );
+            SetProperty(
+                ref defaultMultiRevisionViewMode,
+                value.DefaultMultiRevisionViewMode,
+                nameof(DefaultMultiRevisionViewMode)
+            );
+        });
     }
 
     public ICollectionView ValidRepositoryPaths { get; }
@@ -162,6 +186,30 @@ public sealed class GeneralSettingsViewModel : INotifyPropertyChanged, IDisposab
         }
     }
 
+    public LogRevisionViewMode DefaultSingleRevisionViewMode
+    {
+        get => defaultSingleRevisionViewMode;
+        set
+        {
+            if (SetProperty(ref defaultSingleRevisionViewMode, value))
+            {
+                logStorage.Update(snapshot => snapshot.DefaultSingleRevisionViewMode = value);
+            }
+        }
+    }
+
+    public LogRevisionViewMode DefaultMultiRevisionViewMode
+    {
+        get => defaultMultiRevisionViewMode;
+        set
+        {
+            if (SetProperty(ref defaultMultiRevisionViewMode, value))
+            {
+                logStorage.Update(snapshot => snapshot.DefaultMultiRevisionViewMode = value);
+            }
+        }
+    }
+
     public ICommand OpenSettingsFolderCommand { get; }
     public ICommand SearchRootFolderCommand { get; }
     public ICommand AddRepositoryCommand { get; }
@@ -169,7 +217,11 @@ public sealed class GeneralSettingsViewModel : INotifyPropertyChanged, IDisposab
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public void Dispose() => unsubscribeOptions.Dispose();
+    public void Dispose()
+    {
+        unsubscribeOptions.Dispose();
+        unsubscribeLogOptions.Dispose();
+    }
 
     private bool SetProperty<T>(ref T prop, T value, [CallerMemberName] string? propertyName = null)
     {

--- a/GitOut/Features/Settings/SettingsPage.xaml
+++ b/GitOut/Features/Settings/SettingsPage.xaml
@@ -17,6 +17,7 @@
   x:Name="Root"
 >
   <UserControl.Resources>
+    <converters:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     <Style
       x:Key="GridHeaderTextBoxStyle"
       TargetType="{x:Type TextBox}"
@@ -216,6 +217,105 @@
               <StackPanel>
                 <TextBlock Style="{StaticResource Header6TextStyle}" Text="Staging" />
                 <staging:StageSettings />
+              </StackPanel>
+            </Border>
+            <Border Style="{StaticResource CardPanelStyle}">
+              <StackPanel>
+                <TextBlock Style="{StaticResource Header6TextStyle}" Text="Log" />
+                <TextBlock
+                  Margin="0 8 0 4"
+                  Style="{StaticResource SecondaryTextStyle}"
+                  Text="Default single file view mode"
+                />
+                <ItemsControl Style="{StaticResource MaterialTextToggleButtonGroupStyle}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <WrapPanel />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                  <ToggleButton IsChecked="{Binding DefaultSingleRevisionViewMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=CurrentRevision}">
+                    <StackPanel Orientation="Horizontal">
+                      <Path
+                        Fill="{DynamicResource MaterialForegroundBase}"
+                        Data="{StaticResource FileTree}"
+                        Width="14"
+                        Height="14"
+                        Stretch="Uniform"
+                        Margin="0 0 4 0"
+                        VerticalAlignment="Center"
+                      />
+                      <TextBlock Text="FILE TREE" VerticalAlignment="Center" />
+                    </StackPanel>
+                  </ToggleButton>
+                  <ToggleButton IsChecked="{Binding DefaultSingleRevisionViewMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Diff}">
+                    <StackPanel Orientation="Horizontal">
+                      <Path
+                        Fill="{DynamicResource MaterialForegroundBase}"
+                        Data="{StaticResource FileTree}"
+                        Width="14"
+                        Height="14"
+                        Stretch="Uniform"
+                        Margin="0 0 4 0"
+                        VerticalAlignment="Center"
+                      />
+                      <TextBlock Text="DIFF TREE" VerticalAlignment="Center" />
+                    </StackPanel>
+                  </ToggleButton>
+                  <ToggleButton IsChecked="{Binding DefaultSingleRevisionViewMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=DiffInline}">
+                    <StackPanel Orientation="Horizontal">
+                      <Path
+                        Fill="{DynamicResource MaterialForegroundBase}"
+                        Data="{StaticResource FormatListBullet}"
+                        Width="14"
+                        Height="14"
+                        Stretch="Uniform"
+                        Margin="0 0 4 0"
+                        VerticalAlignment="Center"
+                      />
+                      <TextBlock Text="DIFF LIST" VerticalAlignment="Center" />
+                    </StackPanel>
+                  </ToggleButton>
+                </ItemsControl>
+                <TextBlock
+                  Margin="0 8 0 4"
+                  Style="{StaticResource SecondaryTextStyle}"
+                  Text="Default multi file view mode"
+                />
+                <ItemsControl Style="{StaticResource MaterialTextToggleButtonGroupStyle}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <WrapPanel />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                  <ToggleButton IsChecked="{Binding DefaultMultiRevisionViewMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Diff}">
+                    <StackPanel Orientation="Horizontal">
+                      <Path
+                        Fill="{DynamicResource MaterialForegroundBase}"
+                        Data="{StaticResource FileTree}"
+                        Width="14"
+                        Height="14"
+                        Stretch="Uniform"
+                        Margin="0 0 4 0"
+                        VerticalAlignment="Center"
+                      />
+                      <TextBlock Text="DIFF TREE" VerticalAlignment="Center" />
+                    </StackPanel>
+                  </ToggleButton>
+                  <ToggleButton IsChecked="{Binding DefaultMultiRevisionViewMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=DiffInline}">
+                    <StackPanel Orientation="Horizontal">
+                      <Path
+                        Fill="{DynamicResource MaterialForegroundBase}"
+                        Data="{StaticResource FormatListBullet}"
+                        Width="14"
+                        Height="14"
+                        Stretch="Uniform"
+                        Margin="0 0 4 0"
+                        VerticalAlignment="Center"
+                      />
+                      <TextBlock Text="DIFF LIST" VerticalAlignment="Center" />
+                    </StackPanel>
+                  </ToggleButton>
+                </ItemsControl>
               </StackPanel>
             </Border>
             <Border Style="{StaticResource CardPanelStyle}">

--- a/GitOut/Features/Settings/SettingsViewModel.cs
+++ b/GitOut/Features/Settings/SettingsViewModel.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Windows.Data;
 using GitOut.Features.Diagnostics;
 using GitOut.Features.Git;
+using GitOut.Features.Git.Log;
 using GitOut.Features.Git.RepositoryList;
 using GitOut.Features.Git.Stage;
 using GitOut.Features.Git.Storage;
@@ -34,6 +35,8 @@ public sealed class SettingsViewModel : INotifyPropertyChanged, INavigationFallb
         IGitRepositoryFactory gitFactory,
         IOptionsMonitor<GitStageOptions> stageOptions,
         IOptionsWriter<GitStageOptions> storage,
+        IOptionsMonitor<GitLogOptions> logOptions,
+        IOptionsWriter<GitLogOptions> logStorage,
         IProcessTelemetryCollector telemetry
     )
     {
@@ -45,7 +48,9 @@ public sealed class SettingsViewModel : INotifyPropertyChanged, INavigationFallb
             repositories,
             gitFactory,
             stageOptions,
-            storage
+            storage,
+            logOptions,
+            logStorage
         );
         content = general;
         MenuItem[] menuItems = new[]

--- a/GitOut/Themes/Material/MaterialDesign.xaml
+++ b/GitOut/Themes/Material/MaterialDesign.xaml
@@ -1378,6 +1378,80 @@
       </Style>
     </Style.Resources>
   </Style>
+  <Style x:Key="MaterialTextToggleButtonGroupStyle" TargetType="{x:Type ItemsControl}">
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <UniformGrid Rows="1" IsItemsHost="True" />
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ItemsControl}">
+          <Border
+            CornerRadius="3"
+            BorderThickness="1"
+            BorderBrush="{DynamicResource MaterialDarkDividers}"
+            Padding="0"
+          >
+            <ItemsPresenter />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Style.Resources>
+      <Style TargetType="{x:Type ToggleButton}">
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="TextElement.FontWeight" Value="Medium" />
+        <Setter Property="Padding" Value="12 8" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="Template">
+          <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ToggleButton}">
+              <Border
+                x:Name="Bd"
+                CornerRadius="0"
+                BorderThickness="0"
+                Background="{TemplateBinding Background}"
+                TextElement.Foreground="{TemplateBinding Foreground}"
+                TextElement.FontSize="{TemplateBinding FontSize}"
+                TextElement.FontFamily="{TemplateBinding FontFamily}"
+              >
+                <ContentPresenter
+                  Margin="{TemplateBinding Padding}"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                />
+              </Border>
+              <ControlTemplate.Triggers>
+                <Trigger Property="IsEnabled" Value="False">
+                  <Setter
+                    Property="Foreground"
+                    Value="{DynamicResource MaterialLightDisabledText}"
+                  />
+                </Trigger>
+                <Trigger Property="IsChecked" Value="True">
+                  <Setter
+                    Property="Background"
+                    Value="{DynamicResource MaterialBackgroundBackground}"
+                  />
+                </Trigger>
+                <Trigger Property="IsMouseOver" Value="True">
+                  <Setter Property="Background" Value="{DynamicResource MaterialBackgroundHover}" />
+                </Trigger>
+              </ControlTemplate.Triggers>
+            </ControlTemplate>
+          </Setter.Value>
+        </Setter>
+      </Style>
+    </Style.Resources>
+  </Style>
   <Style x:Key="MaterialCheckBoxStyle" TargetType="{x:Type CheckBox}">
     <Setter Property="Cursor" Value="Hand" />
     <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />


### PR DESCRIPTION
adds a new section in settings
<img width="388" height="188" alt="image" src="https://github.com/user-attachments/assets/06e0d781-16c5-44c8-9b59-f2d1369a4ad1" />

that sets the default revision modes in git log view
<img width="197" height="51" alt="image" src="https://github.com/user-attachments/assets/cd6c6376-41d6-4961-9da7-6e97d141ecdd" />

