### PR TITLE
feature(log): add worktree indicator in branch label

### DIFF
--- a/GitOut/Features/Git/GitBranchName.cs
+++ b/GitOut/Features/Git/GitBranchName.cs
@@ -12,7 +12,12 @@ public class GitBranchName
         "^([\\w\\d\\(])(?:[\\w\\d\\- +@&\\/\\{}.\\(\\)]+)(?<![\\/\\.])$"
     );
 
-    private GitBranchName(string type, string name, GitBranchName? upstream = null)
+    private GitBranchName(
+        string type,
+        string name,
+        GitBranchName? upstream = null,
+        bool hasWorktree = false
+    )
     {
         if (name.Length <= 1)
         {
@@ -25,6 +30,7 @@ public class GitBranchName
         Type = type;
         Name = name;
         Upstream = upstream;
+        HasWorktree = hasWorktree;
         IconResource = type switch
         {
             LocalBranchType => "SourceCommitLocal",
@@ -37,6 +43,8 @@ public class GitBranchName
     public string Name { get; }
     public GitBranchName? Upstream { get; }
 
+    public bool HasWorktree { get; }
+
     public string IconResource { get; }
 
     public bool IsLocalBranchType => Type == LocalBranchType;
@@ -46,7 +54,11 @@ public class GitBranchName
     public static bool IsValid(string? name) =>
         name is not null && name.Length > 1 && ValidBranchName.IsMatch(name);
 
-    public static GitBranchName Create(string name, GitBranchName? upstream = null)
+    public static GitBranchName Create(
+        string name,
+        GitBranchName? upstream = null,
+        bool hasWorktree = false
+    )
     {
         if (!name.StartsWith("refs"))
         {
@@ -54,8 +66,8 @@ public class GitBranchName
         }
         string[] parts = name.Split('/', 3);
         return parts.Length > 2
-            ? new GitBranchName(parts[1], parts[2], upstream)
-            : new GitBranchName(parts[1], parts[1], upstream);
+            ? new GitBranchName(parts[1], parts[2], upstream, hasWorktree)
+            : new GitBranchName(parts[1], parts[1], upstream, hasWorktree);
     }
 
     public static GitBranchName CreateLocal(string name) => new(LocalBranchType, name);

--- a/GitOut/Features/Git/LocalGitRepository.cs
+++ b/GitOut/Features/Git/LocalGitRepository.cs
@@ -171,12 +171,12 @@ public sealed class LocalGitRepository : IGitRepository
 
         IGitProcess branches = CreateProcess(
             ProcessOptions.FromArguments(
-                "for-each-ref --sort=-committerdate refs --format=\"%(objectname) %(refname) %(upstream)\""
+                "for-each-ref --sort=-committerdate refs --format=\"%(objectname)|%(refname)|%(upstream)|%(worktreepath)\""
             )
         );
         await foreach (string line in branches.ReadLinesAsync())
         {
-            string[] parts = line.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+            string[] parts = line.Split('|', 4);
             if (parts.Length < 2)
             {
                 continue;
@@ -184,8 +184,12 @@ public sealed class LocalGitRepository : IGitRepository
             var id = GitCommitId.FromHash(parts[0]);
             if (historyByCommitId.TryGetValue(id, out GitHistoryEvent? logitem))
             {
-                GitBranchName? upstream = parts.Length == 3 ? GitBranchName.Create(parts[2]) : null;
-                var branch = GitBranchName.Create(parts[1], upstream);
+                GitBranchName? upstream =
+                    parts.Length >= 3 && parts[2].Length > 0
+                        ? GitBranchName.Create(parts[2])
+                        : null;
+                bool hasWorktree = parts.Length >= 4 && parts[3].Length > 0;
+                var branch = GitBranchName.Create(parts[1], upstream, hasWorktree);
                 logitem.Branches.Add(branch);
             }
         }

--- a/GitOut/Features/Git/Log/GitLogPage.xaml
+++ b/GitOut/Features/Git/Log/GitLogPage.xaml
@@ -1062,6 +1062,20 @@
                               />
                             </Canvas>
                             <TextBlock Text="{Binding Name}" />
+                            <Canvas
+                              Width="24"
+                              Height="24"
+                              Margin="4 0 0 0"
+                              Visibility="{Binding HasWorktree, Converter={StaticResource BooleanToVisibilityConverter}}"
+                            >
+                              <Canvas.LayoutTransform>
+                                <ScaleTransform ScaleX=".5" ScaleY=".5" />
+                              </Canvas.LayoutTransform>
+                              <Path
+                                Fill="{DynamicResource MaterialForegroundBase}"
+                                Data="{StaticResource Forest}"
+                              />
+                            </Canvas>
                           </StackPanel>
                         </Border>
                       </DataTemplate>


### PR DESCRIPTION
Adds a small forest icon if the branch is part of a worktree

<img width="196" height="168" alt="image" src="https://github.com/user-attachments/assets/172e0407-2e6a-4e1b-83d0-510c72d3a323" />
